### PR TITLE
Update virtual-background package to 2022.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.4",
         "@shiguredo/noise-suppression": "^2022.4.2",
-        "@shiguredo/virtual-background": "^2022.5.0",
+        "@shiguredo/virtual-background": "^2022.6.0",
         "bootstrap": "5.2.0",
         "query-string": "^7.1.1",
         "react": "^18.2.0",
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/@shiguredo/virtual-background": {
-      "version": "2022.5.0",
-      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.5.0.tgz",
-      "integrity": "sha512-F8Pd6vwRBVioTiCHcSOrGasREXmWOFlbso37IdNvSOaxpv5i2FS0zNOFLTLcz7w/XEjQh/tdccnY72M1BW0NTQ==",
+      "version": "2022.6.0",
+      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.6.0.tgz",
+      "integrity": "sha512-0p0Fav9b5dXkPRp6xHpNukNycbAOr8Q3MB8JvrwzJNHk16TCXiLPR4OjQ0Y5L1GoGGNQqk1g5GaqS1qo0Z/esA==",
       "dependencies": {
         "@types/dom-mediacapture-transform": "^0.1.3"
       }
@@ -7972,9 +7972,9 @@
       }
     },
     "@shiguredo/virtual-background": {
-      "version": "2022.5.0",
-      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.5.0.tgz",
-      "integrity": "sha512-F8Pd6vwRBVioTiCHcSOrGasREXmWOFlbso37IdNvSOaxpv5i2FS0zNOFLTLcz7w/XEjQh/tdccnY72M1BW0NTQ==",
+      "version": "2022.6.0",
+      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.6.0.tgz",
+      "integrity": "sha512-0p0Fav9b5dXkPRp6xHpNukNycbAOr8Q3MB8JvrwzJNHk16TCXiLPR4OjQ0Y5L1GoGGNQqk1g5GaqS1qo0Z/esA==",
       "requires": {
         "@types/dom-mediacapture-transform": "^0.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.4",
     "@shiguredo/noise-suppression": "^2022.4.2",
-    "@shiguredo/virtual-background": "^2022.5.0",
+    "@shiguredo/virtual-background": "^2022.6.0",
     "bootstrap": "5.2.0",
     "query-string": "^7.1.1",
     "react": "^18.2.0",


### PR DESCRIPTION
`@shiguredo/virtual-background` を Safari 対応が入った v2022.6.0 に更新します。
既存のソースコードの修正は必要がない認識です（ `VirtualBackgroundProcessor.isSupported()` で有効・無効が判定されていれば Safari 15.4 以降で、このメソッドが true を返すようになるだけ）。