### PR TITLE
Update @shiguredo/virtual-background to v2022.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.5",
         "@shiguredo/noise-suppression": "^2022.4.2",
-        "@shiguredo/virtual-background": "^2022.6.0",
+        "@shiguredo/virtual-background": "^2022.6.1",
         "bootstrap": "5.2.0",
         "query-string": "^7.1.1",
         "react": "^18.2.0",
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@shiguredo/virtual-background": {
-      "version": "2022.6.0",
-      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.6.0.tgz",
-      "integrity": "sha512-0p0Fav9b5dXkPRp6xHpNukNycbAOr8Q3MB8JvrwzJNHk16TCXiLPR4OjQ0Y5L1GoGGNQqk1g5GaqS1qo0Z/esA==",
+      "version": "2022.6.1",
+      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.6.1.tgz",
+      "integrity": "sha512-UtJ0bpmNNE/hEqrDNTnW7wu8kXEmFOt57BcOSKYKUNp2ReeQnfjB++FeI1eugV1GSxRxkqSlbRNv7bhtcttBOQ==",
       "dependencies": {
         "@types/dom-mediacapture-transform": "^0.1.3"
       }
@@ -8013,9 +8013,9 @@
       }
     },
     "@shiguredo/virtual-background": {
-      "version": "2022.6.0",
-      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.6.0.tgz",
-      "integrity": "sha512-0p0Fav9b5dXkPRp6xHpNukNycbAOr8Q3MB8JvrwzJNHk16TCXiLPR4OjQ0Y5L1GoGGNQqk1g5GaqS1qo0Z/esA==",
+      "version": "2022.6.1",
+      "resolved": "https://registry.npmjs.org/@shiguredo/virtual-background/-/virtual-background-2022.6.1.tgz",
+      "integrity": "sha512-UtJ0bpmNNE/hEqrDNTnW7wu8kXEmFOt57BcOSKYKUNp2ReeQnfjB++FeI1eugV1GSxRxkqSlbRNv7bhtcttBOQ==",
       "requires": {
         "@types/dom-mediacapture-transform": "^0.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.5",
     "@shiguredo/noise-suppression": "^2022.4.2",
-    "@shiguredo/virtual-background": "^2022.6.0",
+    "@shiguredo/virtual-background": "^2022.6.1",
     "bootstrap": "5.2.0",
     "query-string": "^7.1.1",
     "react": "^18.2.0",


### PR DESCRIPTION
`@shiguredo/virtual-background` パッケージを iPhone 対応を行った [v2022.6.1](https://github.com/shiguredo/media-processors/releases/tag/virtual-background-2022.6.1) に更新します。