### PR TITLE
lyraParamsBitrate を設定しても Advanced options が bold にならなかったのを修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,12 @@
 
 ## develop
 
-- [FIX] "copy URL" ボタンを押しても lyraParamsBitrate の値が URL に反映されない問題を修正
-    - @sile
 - [UPDATE] sora-js-sdk を 2023.1.0-canary.0 に更新
     - Lyra 音声コーデックの Safari 対応の取り込み
+    - @sile
+- [FIX] lyraParamsBitrate を設定しても Advanced options が bold にならなかったのを修正
+    - @torikizi
+- [FIX] "copy URL" ボタンを押しても lyraParamsBitrate の値が URL に反映されない問題を修正
     - @sile
 - [FIX] 接続中には「lyraParamsBitrate」設定を変更不可にする
     - @sile

--- a/src/components/DevtoolsPane/index.tsx
+++ b/src/components/DevtoolsPane/index.tsx
@@ -211,8 +211,8 @@ const RowSignalingOptions: React.FC = () => {
 const RowAdvancedOptions: React.FC = () => {
   const [collapsed, setCollapsed] = useState(true);
   const audioStreamingLanguageCode = useAppSelector((state) => state.audioStreamingLanguageCode);
-  const lyraParamsBitrateForm = useAppSelector((state) => state.lyraParamsBitrate);
-  const enabledOptions = [audioStreamingLanguageCode !== "", lyraParamsBitrateForm !== ""].some((e) => e);
+  const lyraParamsBitrate = useAppSelector((state) => state.lyraParamsBitrate);
+  const enabledOptions = [audioStreamingLanguageCode !== "", lyraParamsBitrate !== ""].some((e) => e);
   const linkClassNames = ["btn-collapse-options"];
   if (collapsed) {
     linkClassNames.push("collapsed");

--- a/src/components/DevtoolsPane/index.tsx
+++ b/src/components/DevtoolsPane/index.tsx
@@ -211,7 +211,8 @@ const RowSignalingOptions: React.FC = () => {
 const RowAdvancedOptions: React.FC = () => {
   const [collapsed, setCollapsed] = useState(true);
   const audioStreamingLanguageCode = useAppSelector((state) => state.audioStreamingLanguageCode);
-  const enabledOptions = [audioStreamingLanguageCode !== ""].some((e) => e);
+  const lyraParamsBitrateForm = useAppSelector((state) => state.lyraParamsBitrate);
+  const enabledOptions = [audioStreamingLanguageCode !== "", lyraParamsBitrateForm !== ""].some((e) => e);
   const linkClassNames = ["btn-collapse-options"];
   if (collapsed) {
     linkClassNames.push("collapsed");


### PR DESCRIPTION
lyraParamsBitrate を設定した時に Advanced options が bold になるよう修正しました。
ローカルで動作確認をし、期待通りの動作をしていました。