### PR TITLE
role: recvonly かつ multistream 有効時の挙動変更

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@
 
 ## develop
 
-- [CHANGE] role が `recvonly` かつ multistream が `true` または `未指定` の時に video/audio のコーデックとビットレートの項目を表示しない
+- [CHANGE] `Advanced options` を `Advanced signaling options` に変更する
+  - @tnamao
 - [CHANGE] ローカル開発用と本番用で成果物の主力先を分ける
   - `process.env.NODE_ENV` が `production` のときは `dist` に、それ以外は `dev` に出力する
   - @voluntas
@@ -77,6 +78,24 @@
   - @sile
 - [FIX] sora_demo を sora_devtools に修正する
   - @voluntas
+
+### role が recvonly かつ multistream 利用時の表示と挙動の変更
+
+- [CHANGE] video/audio のコーデックとビットレートの項目を表示しない
+  - @tnamao
+- [CHANGE] `Advanced signaling options` の表示をしない
+  - @tnamao
+- [CHANGE] `copy URL` でコピーする URL に次のパラメータを含めない
+  - `audioBitRate`
+  - `audioCodecType`
+  - `videoBitRate`
+  - `videoCodecType`
+  - `audioStreamingLanguageCode`
+  - `audioLyraParamsBitrate`
+  - `videoVP9Params`
+  - `videoH264Params`
+  - `videoAV1params`
+  - @tnamao
 
 ## 2022.5.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,17 @@
   - @tnamao
 - [CHANGE] `Advanced signaling options` の表示をしない
   - @tnamao
+- [CHANGE] シグナリング時のパラメータから次のパラメータを含めず接続する
+  - `audioBitRate`
+  - `audioCodecType`
+  - `videoBitRate`
+  - `videoCodecType`
+  - `audioStreamingLanguageCode`
+  - `audioLyraParamsBitrate`
+  - `videoVP9Params`
+  - `videoH264Params`
+  - `videoAV1params`
+  - @tnamao
 - [CHANGE] `copy URL` でコピーする URL に次のパラメータを含めない
   - `audioBitRate`
   - `audioCodecType`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
 
 - [CHANGE] `Advanced options` を `Advanced signaling options` に変更する
   - @tnamao
+- [CHANGE] `videoCodecType` の初期値をブラウザから自動判別した値から `未指定` に変更する
+  - @tnamao
+- [CHANGE] index ページのマルチストリームのリンクに `videoCodecType=VP9` を追加する
+  - 初期値変更に伴う URL パラメータの追加
+  - @tnamao
 - [CHANGE] ローカル開発用と本番用で成果物の主力先を分ける
   - `process.env.NODE_ENV` が `production` のときは `dist` に、それ以外は `dev` に出力する
   - @voluntas

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -25,7 +25,6 @@ import {
   createVideoConstraints,
   drawFakeCanvas,
   getBlurRadiusNumber,
-  getDefaultVideoCodecType,
   getDevices,
   getLightAdjustmentOptions,
   getMediaStreamTrackProperties,
@@ -138,11 +137,8 @@ export const setInitialParameter = () => {
     if (qsParams.videoBitRate !== undefined) {
       dispatch(slice.actions.setVideoBitRate(qsParams.videoBitRate))
     }
-    // videoCodecType は query string の指定がない場合、ブラウザが対応している codec type を選択する
     if (qsParams.videoCodecType !== undefined) {
       dispatch(slice.actions.setVideoCodecType(qsParams.videoCodecType))
-    } else {
-      dispatch(slice.actions.setVideoCodecType(getDefaultVideoCodecType()))
     }
     if (qsParams.videoVP9Params !== undefined) {
       dispatch(slice.actions.setVideoVP9Params(qsParams.videoVP9Params))

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1013,6 +1013,7 @@ function pickConnectionOptionsState(state: SoraDevtoolsState): ConnectionOptions
     videoVP9Params: state.videoVP9Params,
     videoH264Params: state.videoH264Params,
     videoAV1Params: state.videoAV1Params,
+    role: state.role,
   }
 }
 

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -330,6 +330,10 @@ export const setInitialParameter = () => {
 export const copyURL = () => {
   return (_: Dispatch, getState: () => SoraDevtoolsState): void => {
     const state = getState()
+    const appendAudioVideoParams = !(
+      state.role === 'recvonly' &&
+      (state.multistream === 'true' || state.multistream === '')
+    )
     const parameters: Partial<QueryStringParameters> = {
       channelId: state.channelId,
       role: state.role,
@@ -339,20 +343,24 @@ export const copyURL = () => {
       // URL の長さ短縮のため初期値と同じ場合は query string に含めない
       mediaType: state.mediaType !== 'getUserMedia' ? state.mediaType : undefined,
       // URL の長さ短縮のため空文字列は query string に含めない
-      audioBitRate: state.audioBitRate !== '' ? state.audioBitRate : undefined,
-      audioCodecType: state.audioCodecType !== '' ? state.audioCodecType : undefined,
-      videoBitRate: state.videoBitRate !== '' ? state.videoBitRate : undefined,
-      videoCodecType: state.videoCodecType !== '' ? state.videoCodecType : undefined,
+      audioBitRate:
+        appendAudioVideoParams && state.audioBitRate !== '' ? state.audioBitRate : undefined,
+      audioCodecType:
+        appendAudioVideoParams && state.audioCodecType !== '' ? state.audioCodecType : undefined,
+      videoBitRate:
+        appendAudioVideoParams && state.videoBitRate !== '' ? state.videoBitRate : undefined,
+      videoCodecType:
+        appendAudioVideoParams && state.videoCodecType !== '' ? state.videoCodecType : undefined,
       videoVP9Params:
-        state.videoVP9Params !== '' && state.enabledVideoVP9Params
+        appendAudioVideoParams && state.videoVP9Params !== '' && state.enabledVideoVP9Params
           ? state.videoVP9Params
           : undefined,
       videoH264Params:
-        state.videoH264Params !== '' && state.enabledVideoH264Params
+        appendAudioVideoParams && state.videoH264Params !== '' && state.enabledVideoH264Params
           ? state.videoH264Params
           : undefined,
       videoAV1Params:
-        state.videoAV1Params !== '' && state.enabledVideoAV1Params
+        appendAudioVideoParams && state.videoAV1Params !== '' && state.enabledVideoAV1Params
           ? state.videoAV1Params
           : undefined,
       audioContentHint: state.audioContentHint !== '' ? state.audioContentHint : undefined,
@@ -424,12 +432,15 @@ export const copyURL = () => {
       mute: state.mute === true ? true : undefined,
       // audioStreamingLanguageCode
       audioStreamingLanguageCode:
-        state.audioStreamingLanguageCode !== '' && state.enabledAudioStreamingLanguageCode
+        appendAudioVideoParams &&
+        state.audioStreamingLanguageCode !== '' &&
+        state.enabledAudioStreamingLanguageCode
           ? state.audioStreamingLanguageCode
           : undefined,
-      audioLyraParamsBitrate: state.audioLyraParamsBitrate
-        ? state.audioLyraParamsBitrate
-        : undefined,
+      audioLyraParamsBitrate:
+        appendAudioVideoParams && state.audioLyraParamsBitrate
+          ? state.audioLyraParamsBitrate
+          : undefined,
     }
     const queryStrings = Object.keys(parameters)
       .map((key) => {

--- a/src/components/DevtoolsPane/index.tsx
+++ b/src/components/DevtoolsPane/index.tsx
@@ -450,6 +450,11 @@ export const RowMediaDevices: React.FC = () => {
 export const DevtoolsPane: React.FC = () => {
   const debug = useAppSelector((state) => state.debug)
   const role = useAppSelector((state) => state.role)
+  const multistream = useAppSelector((state) => state.multistream)
+  const showAdvancedSignalingForms = !(
+    role === 'recvonly' &&
+    (multistream === 'true' || multistream === '')
+  )
   return (
     <div className={debug ? 'col-devtools col-6' : 'col-devtools col-12'}>
       <AlertMessages />
@@ -459,7 +464,7 @@ export const DevtoolsPane: React.FC = () => {
       <hr className="hr-form" />
       <RowGetUserMediaConstraints />
       <RowSignalingOptions />
-      <RowAdvancedOptions />
+      {showAdvancedSignalingForms && <RowAdvancedOptions />}
       <hr className="hr-form" />
       {role !== 'recvonly' ? (
         <>

--- a/src/components/DevtoolsPane/index.tsx
+++ b/src/components/DevtoolsPane/index.tsx
@@ -231,7 +231,7 @@ const RowSignalingOptions: React.FC = () => {
   )
 }
 
-const RowAdvancedOptions: React.FC = () => {
+const RowAdvancedSignalingOptions: React.FC = () => {
   const [collapsed, setCollapsed] = useState(true)
   const audioStreamingLanguageCode = useAppSelector((state) => state.audioStreamingLanguageCode)
   const audioLyraParamsBitrate = useAppSelector((state) => state.audioLyraParamsBitrate)
@@ -260,7 +260,7 @@ const RowAdvancedOptions: React.FC = () => {
     <Row className="form-row">
       <Col>
         <a href="#" className={linkClassNames.join(' ')} onClick={onClick}>
-          Advanced options
+          Advanced signaling options
         </a>
       </Col>
       <Collapse in={!collapsed}>
@@ -464,7 +464,7 @@ export const DevtoolsPane: React.FC = () => {
       <hr className="hr-form" />
       <RowGetUserMediaConstraints />
       <RowSignalingOptions />
-      {showAdvancedSignalingForms && <RowAdvancedOptions />}
+      {showAdvancedSignalingForms && <RowAdvancedSignalingOptions />}
       <hr className="hr-form" />
       {role !== 'recvonly' ? (
         <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,15 +53,15 @@ const Index: React.FC = () => {
             <li className="separator">マルチストリーム</li>
             <Link
               pageName="マルチストリーム送受信"
-              params={{ role: 'sendrecv', multistream: true }}
+              params={{ role: 'sendrecv', multistream: true, videoCodecType: 'VP9' }}
             />
             <Link
               pageName="マルチストリーム送信のみ"
-              params={{ role: 'sendonly', multistream: true }}
+              params={{ role: 'sendonly', multistream: true, videoCodecType: 'VP9' }}
             />
             <Link
               pageName="マルチストリーム受信のみ"
-              params={{ role: 'recvonly', multistream: true }}
+              params={{ role: 'recvonly', multistream: true, videoCodecType: 'VP9' }}
             />
             <Link
               pageName="マルチストリーム送受信 (サイマルキャスト有効)"

--- a/src/types.ts
+++ b/src/types.ts
@@ -367,6 +367,7 @@ export type ConnectionOptionsState = Pick<
   | 'videoVP9Params'
   | 'videoH264Params'
   | 'videoAV1Params'
+  | 'role'
 >
 
 // ダウンロードレポートに使用するパラメーター

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -702,6 +702,18 @@ export function createConnectOptions(
     if (connectionOptionsState.enabledVideoAV1Params) {
       connectionOptions.videoAV1Params = parseMetadata(true, connectionOptionsState.videoAV1Params)
     }
+    // audioStreamingLanguageCode
+    if (connectionOptionsState.enabledAudioStreamingLanguageCode) {
+      connectionOptions.audioStreamingLanguageCode =
+        connectionOptionsState.audioStreamingLanguageCode
+    }
+    // audioLyraParamsBitrate
+    if (connectionOptionsState.audioLyraParamsBitrate) {
+      connectionOptions.audioLyraParamsBitrate = parseInt(
+        connectionOptionsState.audioLyraParamsBitrate,
+        10,
+      ) as 3200 | 6000 | 9200
+    }
   }
   // multistream
   const parsedMultistream = parseBooleanString(connectionOptionsState.multistream)
@@ -785,17 +797,6 @@ export function createConnectOptions(
     if (Array.isArray(dataChannels)) {
       connectionOptions.dataChannels = dataChannels
     }
-  }
-  // audioStreamingLanguageCode
-  if (connectionOptionsState.enabledAudioStreamingLanguageCode) {
-    connectionOptions.audioStreamingLanguageCode = connectionOptionsState.audioStreamingLanguageCode
-  }
-  // audioLyraParamsBitrate
-  if (connectionOptionsState.audioLyraParamsBitrate) {
-    connectionOptions.audioLyraParamsBitrate = parseInt(
-      connectionOptionsState.audioLyraParamsBitrate,
-      10,
-    ) as 3200 | 6000 | 9200
   }
   return connectionOptions
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -663,35 +663,45 @@ export function createConnectOptions(
     audio: connectionOptionsState.audio,
     video: connectionOptionsState.video,
   }
-  // audioCodecType
-  if (connectionOptionsState.audioCodecType) {
-    connectionOptions.audioCodecType = connectionOptionsState.audioCodecType
-  }
-  // audioBitRate
-  const parsedAudioBitRate = parseInt(connectionOptionsState.audioBitRate, 10)
-  if (parsedAudioBitRate) {
-    connectionOptions.audioBitRate = parsedAudioBitRate
-  }
-  // videoCodecType
-  if (connectionOptionsState.videoCodecType) {
-    connectionOptions.videoCodecType = connectionOptionsState.videoCodecType
-  }
-  // videoBitRate
-  const parsedVideoBitRate = parseInt(connectionOptionsState.videoBitRate, 10)
-  if (parsedVideoBitRate) {
-    connectionOptions.videoBitRate = parsedVideoBitRate
-  }
-  // videoVP9Params
-  if (connectionOptionsState.enabledVideoVP9Params) {
-    connectionOptions.videoVP9Params = parseMetadata(true, connectionOptionsState.videoVP9Params)
-  }
-  // videoH264Params
-  if (connectionOptionsState.enabledVideoH264Params) {
-    connectionOptions.videoH264Params = parseMetadata(true, connectionOptionsState.videoH264Params)
-  }
-  // videoVP9Params
-  if (connectionOptionsState.enabledVideoAV1Params) {
-    connectionOptions.videoAV1Params = parseMetadata(true, connectionOptionsState.videoAV1Params)
+  // recvonly かつ multistream の時は audio/video のパラメータを送らない
+  const sendAudioVideoParams = !(
+    connectionOptionsState.role === 'recvonly' &&
+    (connectionOptionsState.multistream === 'true' || connectionOptionsState.multistream === '')
+  )
+  if (sendAudioVideoParams) {
+    // audioCodecType
+    if (connectionOptionsState.audioCodecType) {
+      connectionOptions.audioCodecType = connectionOptionsState.audioCodecType
+    }
+    // audioBitRate
+    const parsedAudioBitRate = parseInt(connectionOptionsState.audioBitRate, 10)
+    if (parsedAudioBitRate) {
+      connectionOptions.audioBitRate = parsedAudioBitRate
+    }
+    // videoCodecType
+    if (connectionOptionsState.videoCodecType) {
+      connectionOptions.videoCodecType = connectionOptionsState.videoCodecType
+    }
+    // videoBitRate
+    const parsedVideoBitRate = parseInt(connectionOptionsState.videoBitRate, 10)
+    if (parsedVideoBitRate) {
+      connectionOptions.videoBitRate = parsedVideoBitRate
+    }
+    // videoVP9Params
+    if (connectionOptionsState.enabledVideoVP9Params) {
+      connectionOptions.videoVP9Params = parseMetadata(true, connectionOptionsState.videoVP9Params)
+    }
+    // videoH264Params
+    if (connectionOptionsState.enabledVideoH264Params) {
+      connectionOptions.videoH264Params = parseMetadata(
+        true,
+        connectionOptionsState.videoH264Params,
+      )
+    }
+    // videoVP9Params
+    if (connectionOptionsState.enabledVideoAV1Params) {
+      connectionOptions.videoAV1Params = parseMetadata(true, connectionOptionsState.videoAV1Params)
+    }
   }
   // multistream
   const parsedMultistream = parseBooleanString(connectionOptionsState.multistream)


### PR DESCRIPTION
#411 からの追加変更

### role が recvonly かつ multistream 利用時の表示と挙動の変更

- [CHANGE] `Advanced signaling options` の表示をしない
  - @tnamao
- [CHANGE] シグナリング時のパラメータから次のパラメータを含めず接続する
  - `audioBitRate`
  - `audioCodecType`
  - `videoBitRate`
  - `videoCodecType`
  - `audioStreamingLanguageCode`
  - `audioLyraParamsBitrate`
  - `videoVP9Params`
  - `videoH264Params`
  - `videoAV1params`
  - @tnamao
- [CHANGE] `copy URL` でコピーする URL に次のパラメータを含めない
  - `audioBitRate`
  - `audioCodecType`
  - `videoBitRate`
  - `videoCodecType`
  - `audioStreamingLanguageCode`
  - `audioLyraParamsBitrate`
  - `videoVP9Params`
  - `videoH264Params`
  - `videoAV1params`
  - @tnamao

### その他

- [CHANGE] `Advanced options` を `Advanced signaling options` に変更する
  - @tnamao
- [CHANGE] `videoCodecType` の初期値をブラウザから自動判別した値から `未指定` に変更する
  - @tnamao
- [CHANGE] index ページのマルチストリームのリンクに `videoCodecType=VP9` を追加する
  - 初期値変更に伴う URL パラメータの追加
  - @tnamao
