### PR TITLE
recvonly のリンクからビデオコーデック関連のパラメータは削除

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 ## develop
 
-- [CHANGE] index ページの受信のみのリンクから、ビデオコーデック関連のパラメータを削除する
+- [FIX] index ページの受信のみのリンクから、ビデオコーデック関連のパラメータを削除する
   - 受信時に `videoCodecType` `videoBitRate` は不要なため
   - @tnamao
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [CHANGE] index ページの受信のみのリンクから、ビデオコーデック関連のパラメータを削除する
+  - 受信時に `videoCodecType` `videoBitRate` は不要なため
+  - @tnamao
+
 ## 2023.1.0
 
 - [UPDATE] sora-js-sdk を 2023.1.0 に更新する

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,7 +61,7 @@ const Index: React.FC = () => {
             />
             <Link
               pageName="マルチストリーム受信のみ"
-              params={{ role: 'recvonly', multistream: true, videoCodecType: 'VP9' }}
+              params={{ role: 'recvonly', multistream: true }}
             />
             <Link
               pageName="マルチストリーム送受信 (サイマルキャスト有効)"
@@ -91,7 +91,6 @@ const Index: React.FC = () => {
                 role: 'recvonly',
                 multistream: true,
                 simulcast: true,
-                videoCodecType: 'VP8',
               }}
             />
             <li className="separator">スポットライト</li>
@@ -124,8 +123,6 @@ const Index: React.FC = () => {
                 multistream: true,
                 simulcast: true,
                 spotlight: true,
-                videoCodecType: 'VP8',
-                videoBitRate: '500',
               }}
             />
             <Link
@@ -154,8 +151,6 @@ const Index: React.FC = () => {
                 role: 'recvonly',
                 multistream: true,
                 spotlight: true,
-                videoCodecType: 'VP8',
-                videoBitRate: '500',
               }}
             />
             <li className="separator">データチャネルメッセージング</li>


### PR DESCRIPTION
- [FIX] index ページの受信のみのリンクから、ビデオコーデック関連のパラメータを削除する
  - 受信時に `videoCodecType` `videoBitRate` は不要なため
  - @tnamao
