### PR TITLE
.pnpm-store/ を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ wasm.wasm
 next-env.d.ts
 *.tsbuildinfo
 .DS_Store
+.pnpm-store/
 
 # next dev は distDir に dev を利用する
 dev/


### PR DESCRIPTION
Dev container を使うと .pnpm-store が container 内にできてしまうことがあり、その場合には無視したい。
https://pnpm.io/npmrc#node-modules-settings によると同一 mounted disk 上に home がないのが原因。