### PR TITLE
mediaType に getUserMedia 以外が選択された時の audioInput / videoInput のフォームの扱いを変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [CHANGE] mediaType が getUserMedia 以外の場合は audioInput / videoInput のフォームは表示しない
+  - @tnamao
+- [CHANGE] mediaType が getUserMedia 以外の場合は、copy URL をクリックした時にクリップボードにコピーする URL のパラメータに audioInput / videoInput を含めない
+  - @tnamao
 - [CHANGE] Node.js 16 系を落とす
   - @voluntas
 - [CHANGE] GA の main.yml を ci.yml に変更する

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -383,9 +383,15 @@ export const copyURL = () => {
       spotlightNumber: state.spotlightNumber !== '' ? state.spotlightNumber : undefined,
       spotlightFocusRid: state.spotlightFocusRid !== '' ? state.spotlightFocusRid : undefined,
       spotlightUnfocusRid: state.spotlightUnfocusRid !== '' ? state.spotlightUnfocusRid : undefined,
-      audioInput: state.audioInput !== '' ? state.audioInput : undefined,
+      audioInput:
+        state.mediaType === 'getUserMedia' && state.audioInput !== ''
+          ? state.audioInput
+          : undefined,
       audioOutput: state.audioOutput !== '' ? state.audioOutput : undefined,
-      videoInput: state.videoInput !== '' ? state.videoInput : undefined,
+      videoInput:
+        state.mediaType === 'getUserMedia' && state.videoInput !== ''
+          ? state.videoInput
+          : undefined,
       displayResolution: state.displayResolution !== '' ? state.displayResolution : undefined,
       bundleId: state.bundleId !== '' && state.enabledBundleId ? state.bundleId : undefined,
       clientId: state.clientId !== '' && state.enabledClientId ? state.clientId : undefined,

--- a/src/components/DevtoolsPane/index.tsx
+++ b/src/components/DevtoolsPane/index.tsx
@@ -400,9 +400,13 @@ const RowMediaOptions: React.FC = () => {
 
 const RowDevices: React.FC = () => {
   const role = useAppSelector((state) => state.role);
+  const mediaType = useAppSelector((state) => state.mediaType);
   return (
     <Row className="form-row" xs="auto">
-      {role !== 'recvonly' ? (
+      {/**
+       * role が recvonly かつ mediaType が getUserMedia の場合のみ、Audio / Video InputForm を表示する
+       */}
+      {role !== 'recvonly' && mediaType === 'getUserMedia' ? (
         <>
           <Col>
             <AudioInputForm />


### PR DESCRIPTION
### 変更履歴

- [CHANGE] mediaType が getUserMedia 以外の場合は audioInput / videoInput のフォームは表示しない
  - @tnamao
- [CHANGE] mediaType が getUserMedia 以外の場合は、copy URL をクリックした時にクリップボードにコピーする URL のパラメータに audioInput / videoInput を含めない
  - @tnamao
