### PR TITLE
デバイス無効化時の Track の停止漏れを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX]  `request media` `connect` を実行した後に、`Enable mic device` `Enable video device` のトグルでデバイスを無効化した時に Media Processor が保持している Track の停止漏れを修正する
+  - トグル切替でマイクやカメラのデバイスを無効化してもカメラ等のデバイスが使用中の状態のままになってしまっていた
+  - @tnamao
 - [ADD] Sora とは接続せず Audio / Video デバイスの表示確認と停止を行う `request media` `dispose media` 機能を追加する
   - 現状の設定項目を利用するため、`request media` の実行中は `role` や `mediaType` を disabled にする
   - @tnamao

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -872,65 +872,11 @@ function setSoraCallbacks(
         createSoraDevtoolsTimelineMessage('event-on-disconnect', message),
       ),
     );
-    const {
-      fakeContents,
-      soraContents,
-      reconnect,
-      lightAdjustmentProcessor,
-      noiseSuppressionProcessor,
-      virtualBackgroundProcessor,
-    } = getState();
-    const { localMediaStream, remoteMediaStreams } = soraContents;
-    let originalTrack;
-    if (lightAdjustmentProcessor && lightAdjustmentProcessor.isProcessing()) {
-      originalTrack = lightAdjustmentProcessor.getOriginalTrack();
-      lightAdjustmentProcessor.stopProcessing();
-    }
-    if (virtualBackgroundProcessor && virtualBackgroundProcessor.isProcessing()) {
-      if (originalTrack === undefined) {
-        originalTrack = virtualBackgroundProcessor.getOriginalTrack();
-      }
-      virtualBackgroundProcessor.stopProcessing();
-    }
-    if (originalTrack !== undefined) {
-      originalTrack.stop();
-      dispatch(
-        slice.actions.setTimelineMessage(
-          createSoraDevtoolsMediaStreamTrackLog('stop', originalTrack),
-        ),
-      );
-    } else {
-      if (localMediaStream) {
-        localMediaStream.getVideoTracks().forEach((track) => {
-          track.stop();
-          dispatch(
-            slice.actions.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog('stop', track)),
-          );
-        });
-      }
-    }
-
-    if (noiseSuppressionProcessor && noiseSuppressionProcessor.isProcessing()) {
-      const originalTrack = noiseSuppressionProcessor.getOriginalTrack();
-      if (originalTrack) {
-        originalTrack.stop();
-        dispatch(
-          slice.actions.setTimelineMessage(
-            createSoraDevtoolsMediaStreamTrackLog('stop', originalTrack),
-          ),
-        );
-      }
-      noiseSuppressionProcessor.stopProcessing();
-    } else {
-      if (localMediaStream) {
-        localMediaStream.getAudioTracks().forEach((track) => {
-          track.stop();
-          dispatch(
-            slice.actions.setTimelineMessage(createSoraDevtoolsMediaStreamTrackLog('stop', track)),
-          );
-        });
-      }
-    }
+    // ローカルの MediaStream の Track と MediaProcessor を止める
+    stopLocalVideoTrack(dispatch, getState());
+    stopLocalAudioTrack(dispatch, getState());
+    const { fakeContents, soraContents, reconnect } = getState();
+    const { remoteMediaStreams } = soraContents;
     remoteMediaStreams.forEach((mediaStream) => {
       mediaStream.getTracks().forEach((track) => {
         track.stop();

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1784,6 +1784,10 @@ export const setCameraDevice = (cameraDevice: boolean) => {
   };
 };
 
+/**
+ * devtools のローカルにもっている MediaStream のうち Video Track と
+ * 映像処理を行っている MediaProcessor の停止を行う関数
+ */
 const stopLocalVideoTrack = (
   dispatch: Dispatch,
   { soraContents, lightAdjustmentProcessor, virtualBackgroundProcessor }: SoraDevtoolsState,
@@ -1819,6 +1823,10 @@ const stopLocalVideoTrack = (
   }
 };
 
+/**
+ * devtools のローカルにもっている MediaStream のうち Video Track と
+ * 映像処理を行っている MediaProcessor の停止を行う関数
+ */
 const stopLocalAudioTrack = (
   dispatch: Dispatch,
   { soraContents, noiseSuppressionProcessor }: SoraDevtoolsState,


### PR DESCRIPTION
### 変更履歴

- [FIX]  `request media` `connect` を実行した後に、`Enable mic device` `Enable video device` のトグルでデバイスを無効化した時に Media Processor が保持している Track の停止漏れを修正する
  - トグル切替でマイクやカメラのデバイスを無効化してもカメラ等のデバイスが使用中の状態のままになってしまっていた
  - @tnamao
