### PR TITLE
type: offer で取得したセッション ID を表示できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 - [ADD] コネクション ID とクライアント ID の表示にラベルを追加する
   - @tnamao
 - [ADD] Sora 接続後にセッション ID の表示を追加する
+  - Sora 2023.2.0 以降は sora-js-sdk が `type: offer` から取得したセッション ID を表示に使用する
+  - それ以外の場合は notify の `connection.created` イベントで取得したセッション ID を表示に使用する
   - @tnamao
 - [FIX] `audio` `video` がともに無効な状態で Sora への接続時に getUserMedia を呼び出してしまう問題を修正する
   - @tnamao
@@ -57,7 +59,7 @@
   - @voluntas
 - [CHANGE] 一時的に ; ありにする
   - @voluntas
-- [UPDATE] sora-js-sdk のバージョンを 2023.2.0-canary.14 に上げる
+- [UPDATE] sora-js-sdk のバージョンを 2023.2.0-canary.15 に上げる
   - @voluntas
 - [UPDATE] @shiguredo/virtual-background のバージョンを 2023.2.0 に上げる
   - @sile

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "redux": "4.2.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.4.2",
-    "sora-js-sdk": "2023.2.0-canary.14"
+    "sora-js-sdk": "2023.2.0-canary.15"
   },
   "devDependencies": {
     "@biomejs/biome": "1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 2.4.2
     version: 2.4.2(redux@4.2.1)
   sora-js-sdk:
-    specifier: 2023.2.0-canary.14
-    version: 2023.2.0-canary.14
+    specifier: 2023.2.0-canary.15
+    version: 2023.2.0-canary.15
 
 devDependencies:
   '@biomejs/biome':
@@ -2922,8 +2922,8 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /sora-js-sdk@2023.2.0-canary.14:
-    resolution: {integrity: sha512-EzyeZobLwfSKkh/fYG0BISEOYDWMGvC97eM475cli7dRDEX3bMCfabRPPm0ZRvY24GYpHDSt7dCNOuzm1ssz9w==}
+  /sora-js-sdk@2023.2.0-canary.15:
+    resolution: {integrity: sha512-bDMlROU68a5PAwW5gZ5oIrasUA8ICRVR9I48c+fKolr8CPlyqd21MMpTjhaEcL/rW7aXXJGyojmdRRePM+iWIA==}
     engines: {node: '>=18'}
     dev: false
 

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -902,7 +902,6 @@ function setSoraCallbacks(
       fakeContents.worker.postMessage({ type: 'stop' })
     }
     dispatch(slice.actions.setSora(null))
-    dispatch(slice.actions.setSoraSessionId(null))
     dispatch(slice.actions.setSoraConnectionStatus('disconnected'))
     dispatch(slice.actions.setLocalMediaStream(null))
     dispatch(slice.actions.removeAllRemoteMediaStreams())

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -371,14 +371,20 @@ export const slice = createSlice({
       if (state.soraContents.sora) {
         state.soraContents.connectionId = state.soraContents.sora.connectionId
         state.soraContents.clientId = state.soraContents.sora.clientId
+        if (state.soraContents.sessionId === null) {
+          state.soraContents.sessionId = state.soraContents.sora.sessionId
+        }
       } else {
         state.soraContents.connectionId = null
         state.soraContents.clientId = null
+        state.soraContents.sessionId = null
         state.soraContents.datachannels = []
       }
     },
-    setSoraSessionId: (state, action: PayloadAction<string | null>) => {
-      state.soraContents.sessionId = action.payload
+    setSoraSessionId: (state, action: PayloadAction<string>) => {
+      if (state.soraContents.sessionId === null) {
+        state.soraContents.sessionId = action.payload
+      }
     },
     setSoraConnectionStatus: (
       state,


### PR DESCRIPTION
### 変更履歴

- [ADD] Sora 接続後にセッション ID の表示を追加する
  - Sora 2023.2.0 以降は sora-js-sdk が `type: offer` から取得したセッション ID を表示に使用する
  - それ以外の場合は notify の `connection.created` イベントで取得したセッション ID を表示に使用する
  - @tnamao
