### PR TITLE
gDM に Audio の MediaConstraints を渡せるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] `getDisplayMedia` 使用時の MediaConstraints に audio も含めるようにする
+  - gDM に渡す MediaConstraint の `audio` パラメータは audio のトグルの状態や `Media options` の設定と連動している
+  - @tnamao
 - [CHANGE] role が `sendonly` の時に `Audio Output` のフォームを非表示にする
   - @tnamao
 - [ADD] LocalVideo でサイマルキャストの rid を変更するボタンにラベルとツールチップを追加する

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -20,7 +20,8 @@ import {
   createConnectOptions,
   createFakeMediaConstraints,
   createFakeMediaStream,
-  createGetDisplayMediaConstraints,
+  createGetDisplayMediaAudioConstraints,
+  createGetDisplayMediaVideoConstraints,
   createSignalingURL,
   createVideoConstraints,
   drawFakeCanvas,
@@ -522,21 +523,32 @@ async function createMediaStream(
     if (navigator.mediaDevices === undefined) {
       throw new Error('Failed to call getUserMedia. Make sure domain is secure')
     }
-    const constraints = createGetDisplayMediaConstraints({
-      frameRate: state.frameRate,
-      resolution: state.resolution,
-      aspectRatio: state.aspectRatio,
-      resizeMode: state.resizeMode,
-    })
+    const mediaConstraints = {
+      audio: createGetDisplayMediaAudioConstraints({
+        autoGainControl: state.autoGainControl,
+        noiseSuppression: state.noiseSuppression,
+        echoCancellation: state.echoCancellation,
+        echoCancellationType: state.echoCancellationType,
+      }),
+      video: createGetDisplayMediaVideoConstraints({
+        frameRate: state.frameRate,
+        resolution: state.resolution,
+        aspectRatio: state.aspectRatio,
+        resizeMode: state.resizeMode,
+      }),
+    }
     dispatch(
-      slice.actions.setLogMessages({ title: LOG_TITLE, description: JSON.stringify(constraints) }),
+      slice.actions.setLogMessages({
+        title: LOG_TITLE,
+        description: JSON.stringify(mediaConstraints),
+      }),
     )
     dispatch(
       slice.actions.setTimelineMessage(
-        createSoraDevtoolsTimelineMessage('media-constraints', constraints),
+        createSoraDevtoolsTimelineMessage('media-constraints', mediaConstraints),
       ),
     )
-    const stream = await navigator.mediaDevices.getDisplayMedia(constraints)
+    const stream = await navigator.mediaDevices.getDisplayMedia(mediaConstraints)
     dispatch(
       slice.actions.setTimelineMessage(
         createSoraDevtoolsTimelineMessage('succeed-get-display-media'),
@@ -563,22 +575,33 @@ async function createMediaStream(
     if (navigator.mediaDevices === undefined) {
       throw new Error('Failed to call getDisplayMedia. Make sure domain is secure')
     }
-    const constraints = createGetDisplayMediaConstraints({
-      frameRate: state.frameRate,
-      resolution: state.resolution,
-      aspectRatio: state.aspectRatio,
-      resizeMode: state.resizeMode,
-    })
-    constraints.preferCurrentTab = true
+    const mediaStreamConstraints = {
+      audio: createGetDisplayMediaAudioConstraints({
+        autoGainControl: state.autoGainControl,
+        noiseSuppression: state.noiseSuppression,
+        echoCancellation: state.echoCancellation,
+        echoCancellationType: state.echoCancellationType,
+      }),
+      video: createGetDisplayMediaVideoConstraints({
+        frameRate: state.frameRate,
+        resolution: state.resolution,
+        aspectRatio: state.aspectRatio,
+        resizeMode: state.resizeMode,
+      }),
+    } as MediaStreamConstraints
+    mediaStreamConstraints.preferCurrentTab = true
     dispatch(
-      slice.actions.setLogMessages({ title: LOG_TITLE, description: JSON.stringify(constraints) }),
+      slice.actions.setLogMessages({
+        title: LOG_TITLE,
+        description: JSON.stringify(mediaStreamConstraints),
+      }),
     )
     dispatch(
       slice.actions.setTimelineMessage(
-        createSoraDevtoolsTimelineMessage('media-constraints', constraints),
+        createSoraDevtoolsTimelineMessage('media-constraints', mediaStreamConstraints),
       ),
     )
-    const stream = await navigator.mediaDevices.getDisplayMedia(constraints)
+    const stream = await navigator.mediaDevices.getDisplayMedia(mediaStreamConstraints)
     const targetElement = document.querySelector('#cropArea')
     if (targetElement === null) {
       throw new Error('Failed to get CropTraget Element')

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -524,7 +524,9 @@ async function createMediaStream(
       throw new Error('Failed to call getUserMedia. Make sure domain is secure')
     }
     const mediaConstraints = {
+      // getDisplayMedia では配信する画面の音声を利用するため、デバイス指定 (audioInput) は使わない
       audio: createGetDisplayMediaAudioConstraints({
+        audio: state.audio,
         autoGainControl: state.autoGainControl,
         noiseSuppression: state.noiseSuppression,
         echoCancellation: state.echoCancellation,
@@ -576,7 +578,9 @@ async function createMediaStream(
       throw new Error('Failed to call getDisplayMedia. Make sure domain is secure')
     }
     const mediaStreamConstraints = {
+      // getDisplayMedia (mediacaptureRegion) では配信する画面の音声を利用するため、デバイス指定 (audioInput) は使わない
       audio: createGetDisplayMediaAudioConstraints({
+        audio: state.audio,
         autoGainControl: state.autoGainControl,
         noiseSuppression: state.noiseSuppression,
         echoCancellation: state.echoCancellation,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -456,6 +456,7 @@ export function createFakeMediaConstraints(
 
 // getDisplayMedia の audio constraints を生成
 type CreateGetDisplayMediaAudioConstraintsParameters = {
+  audio: SoraDevtoolsState['audio']
   autoGainControl: (typeof AUTO_GAIN_CONTROLS)[number]
   noiseSuppression: (typeof NOISE_SUPPRESSIONS)[number]
   echoCancellation: (typeof ECHO_CANCELLATIONS)[number]
@@ -464,7 +465,11 @@ type CreateGetDisplayMediaAudioConstraintsParameters = {
 export function createGetDisplayMediaAudioConstraints(
   parameters: CreateGetDisplayMediaAudioConstraintsParameters,
 ): boolean | MediaTrackConstraints {
-  const { autoGainControl, noiseSuppression, echoCancellation, echoCancellationType } = parameters
+  const { audio, autoGainControl, noiseSuppression, echoCancellation, echoCancellationType } =
+    parameters
+  if (!audio) {
+    return false
+  }
   if (!autoGainControl && !noiseSuppression && !echoCancellation && !echoCancellationType) {
     return true
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -454,19 +454,52 @@ export function createFakeMediaConstraints(
   return constraints
 }
 
+// getDisplayMedia の audio constraints を生成
+type CreateGetDisplayMediaAudioConstraintsParameters = {
+  autoGainControl: (typeof AUTO_GAIN_CONTROLS)[number]
+  noiseSuppression: (typeof NOISE_SUPPRESSIONS)[number]
+  echoCancellation: (typeof ECHO_CANCELLATIONS)[number]
+  echoCancellationType: (typeof ECHO_CANCELLATION_TYPES)[number]
+}
+export function createGetDisplayMediaAudioConstraints(
+  parameters: CreateGetDisplayMediaAudioConstraintsParameters,
+): boolean | MediaTrackConstraints {
+  const { autoGainControl, noiseSuppression, echoCancellation, echoCancellationType } = parameters
+  if (!autoGainControl && !noiseSuppression && !echoCancellation && !echoCancellationType) {
+    return true
+  }
+  const audioConstraints: SoraDevtoolsMediaTrackConstraints = {}
+  const parsedAutoGainControl = parseBooleanString(autoGainControl)
+  if (parsedAutoGainControl !== undefined) {
+    audioConstraints.autoGainControl = parsedAutoGainControl
+  }
+  const parsedNoiseSuppression = parseBooleanString(noiseSuppression)
+  if (parsedNoiseSuppression !== undefined) {
+    audioConstraints.noiseSuppression = parsedNoiseSuppression
+  }
+  const parsedEchoCancellation = parseBooleanString(echoCancellation)
+  if (parsedEchoCancellation !== undefined) {
+    audioConstraints.echoCancellation = parsedEchoCancellation
+  }
+  if (echoCancellationType) {
+    audioConstraints.echoCancellationType = echoCancellationType
+  }
+  return audioConstraints
+}
+
 // getDisplayMedia の video constraints を生成
-type CreateGetDisplayMediaConstraintsParameters = {
+type CreateGetDisplayMediaVideoConstraintsParameters = {
   frameRate: SoraDevtoolsState['frameRate']
   resolution: SoraDevtoolsState['resolution']
   aspectRatio: SoraDevtoolsState['aspectRatio']
   resizeMode: SoraDevtoolsState['resizeMode']
 }
-export function createGetDisplayMediaConstraints(
-  parameters: CreateGetDisplayMediaConstraintsParameters,
-): MediaStreamConstraints {
+export function createGetDisplayMediaVideoConstraints(
+  parameters: CreateGetDisplayMediaVideoConstraintsParameters,
+): boolean | SoraDevtoolsMediaTrackConstraints {
   const { aspectRatio, frameRate, resizeMode, resolution } = parameters
   if (!frameRate && !resolution && !aspectRatio && !resizeMode) {
-    return { video: true }
+    return true
   }
   const videoConstraints: SoraDevtoolsMediaTrackConstraints = {}
   if (frameRate) {
@@ -485,9 +518,7 @@ export function createGetDisplayMediaConstraints(
   if (resizeMode) {
     videoConstraints.resizeMode = resizeMode
   }
-  return {
-    video: videoConstraints,
-  }
+  return videoConstraints
 }
 
 // Fake 用の MediaStream を生成


### PR DESCRIPTION
### 変更履歴

- [CHANGE] `getDisplayMedia` 使用時の MediaConstraints に audio も含めるようにする
  - gDM に渡す MediaConstraint の `audio` パラメータは audio のトグルの状態や `Media options` の設定と連動している
  - @tnamao
