### PR TITLE
各 ID の表示を notify で自身の connection.created を受け取ったタイミングに変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] `Session ID` `Connection ID` `Client ID` の表示を `type: notify` で受け取ったタイミングでの表示に変更する
+  - この変更に伴い、Sora Devtools の Sora 接続状態の確認は state の `soraContents.connectionStatus` の値の確認も追加
+  - @tnamao
 - [CHANGE] オーディオコーデック `LYRA` の設定を削除する
   - 関連するコードと `service-worker.js` の削除
   - next.config.js から不要な設定の削除

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 
 ## develop
 
-- [CHANGE] `Session ID` `Connection ID` `Client ID` の表示を `type: notify` で受け取ったタイミングでの表示に変更する
-  - この変更に伴い、Sora Devtools の Sora 接続状態の確認は state の `soraContents.connectionStatus` の値の確認も追加
+- [CHANGE] `Session ID` と自身の  `Connection ID` `Client ID` の表示を `type: notify` の `connection.created` を受け取ったタイミングでの表示に変更する
+  - この変更に伴い、Sora Devtools の Sora 接続状態の確認は state の `soraContents.connectionStatus` の値の確認も追加する
   - @tnamao
 - [CHANGE] オーディオコーデック `LYRA` の設定を削除する
   - 関連するコードと `service-worker.js` の削除

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1419,7 +1419,7 @@ export const reconnectSora = () => {
     dispatch(slice.actions.setSoraConnectionStatus('connecting'))
     const state = getState()
     // 接続中の場合は切断する
-    if (state.soraContents.sora) {
+    if (state.soraContents.sora && state.soraContents.connectionStatus === 'connected') {
       await state.soraContents.sora.disconnect()
     }
     // シグナリング候補のURLリストを作成する
@@ -1534,7 +1534,7 @@ export const reconnectSora = () => {
 export const disconnectSora = () => {
   return async (dispatch: Dispatch, getState: () => SoraDevtoolsState): Promise<void> => {
     const { soraContents } = getState()
-    if (soraContents.sora) {
+    if (soraContents.sora && soraContents.connectionStatus === 'connected') {
       dispatch(slice.actions.setSoraConnectionStatus('disconnecting'))
       await soraContents.sora.disconnect()
       dispatch(slice.actions.setSoraConnectionStatus('disconnected'))
@@ -1706,7 +1706,11 @@ export const setMicDevice = (micDevice: boolean) => {
         },
       )
       if (0 < mediaStream.getAudioTracks().length) {
-        if (state.soraContents.sora && state.soraContents.localMediaStream) {
+        if (
+          state.soraContents.sora &&
+          state.soraContents.connectionStatus === 'connected' &&
+          state.soraContents.localMediaStream
+        ) {
           // Sora 接続中の場合
           await state.soraContents.sora.replaceAudioTrack(
             state.soraContents.localMediaStream,
@@ -1724,7 +1728,11 @@ export const setMicDevice = (micDevice: boolean) => {
         }
         dispatch(slice.actions.setFakeContentsGainNode(gainNode))
       }
-    } else if (state.soraContents.sora && state.soraContents.localMediaStream) {
+    } else if (
+      state.soraContents.sora &&
+      state.soraContents.connectionStatus === 'connected' &&
+      state.soraContents.localMediaStream
+    ) {
       // Sora 接続中の場合
       stopLocalAudioTrack(
         dispatch,
@@ -1748,7 +1756,11 @@ export const setMicDevice = (micDevice: boolean) => {
 export const setCameraDevice = (cameraDevice: boolean) => {
   return async (dispatch: Dispatch, getState: () => SoraDevtoolsState): Promise<void> => {
     const state = getState()
-    if (!state.soraContents.localMediaStream && !state.soraContents.sora) {
+    if (
+      !state.soraContents.localMediaStream &&
+      !state.soraContents.sora &&
+      state.soraContents.connectionStatus !== 'connected'
+    ) {
       dispatch(slice.actions.setCameraDevice(cameraDevice))
       return
     }
@@ -1790,7 +1802,11 @@ export const setCameraDevice = (cameraDevice: boolean) => {
         },
       )
       if (0 < mediaStream.getVideoTracks().length) {
-        if (state.soraContents.sora && state.soraContents.localMediaStream) {
+        if (
+          state.soraContents.sora &&
+          state.soraContents.connectionStatus === 'connected' &&
+          state.soraContents.localMediaStream
+        ) {
           // Sora 接続中の場合
           state.soraContents.sora.replaceVideoTrack(
             state.soraContents.localMediaStream,
@@ -1808,7 +1824,11 @@ export const setCameraDevice = (cameraDevice: boolean) => {
         }
         dispatch(slice.actions.setFakeContentsGainNode(gainNode))
       }
-    } else if (state.soraContents.sora && state.soraContents.localMediaStream) {
+    } else if (
+      state.soraContents.sora &&
+      state.soraContents.connectionStatus === 'connected' &&
+      state.soraContents.localMediaStream
+    ) {
       // Sora 接続中の場合
       const originalTrack = stopVideoProcessors(
         state.lightAdjustmentProcessor,

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -934,6 +934,7 @@ function setSoraCallbacks(
       fakeContents.worker.postMessage({ type: 'stop' })
     }
     dispatch(slice.actions.setSora(null))
+    dispatch(slice.actions.setSoraSessionId(null))
     dispatch(slice.actions.setSoraConnectionStatus('disconnected'))
     dispatch(slice.actions.setLocalMediaStream(null))
     dispatch(slice.actions.removeAllRemoteMediaStreams())

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -370,20 +370,14 @@ export const slice = createSlice({
       if (state.soraContents.sora) {
         state.soraContents.connectionId = state.soraContents.sora.connectionId
         state.soraContents.clientId = state.soraContents.sora.clientId
-        if (state.soraContents.sessionId === null) {
-          state.soraContents.sessionId = state.soraContents.sora.sessionId
-        }
       } else {
         state.soraContents.connectionId = null
         state.soraContents.clientId = null
-        state.soraContents.sessionId = null
         state.soraContents.datachannels = []
       }
     },
-    setSoraSessionId: (state, action: PayloadAction<string>) => {
-      if (state.soraContents.sessionId === null) {
-        state.soraContents.sessionId = action.payload
-      }
+    setSoraSessionId: (state, action: PayloadAction<string | null>) => {
+      state.soraContents.sessionId = action.payload
     },
     setSoraConnectionStatus: (
       state,

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -367,17 +367,18 @@ export const slice = createSlice({
     },
     setSora: (state, action: PayloadAction<ConnectionPublisher | ConnectionSubscriber | null>) => {
       state.soraContents.sora = <any>action.payload
-      if (state.soraContents.sora) {
-        state.soraContents.connectionId = state.soraContents.sora.connectionId
-        state.soraContents.clientId = state.soraContents.sora.clientId
-      } else {
-        state.soraContents.connectionId = null
-        state.soraContents.clientId = null
+      if (!state.soraContents.sora) {
         state.soraContents.datachannels = []
       }
     },
     setSoraSessionId: (state, action: PayloadAction<string | null>) => {
       state.soraContents.sessionId = action.payload
+    },
+    setSoraConnectionId: (state, action: PayloadAction<string | null>) => {
+      state.soraContents.connectionId = action.payload
+    },
+    setSoraClientId: (state, action: PayloadAction<string | null>) => {
+      state.soraContents.clientId = action.payload
     },
     setSoraConnectionStatus: (
       state,

--- a/src/components/DebugPane/SendDataChannelMessagingMessage.tsx
+++ b/src/components/DebugPane/SendDataChannelMessagingMessage.tsx
@@ -8,13 +8,14 @@ export const SendDataChannelMessagingMessage: React.FC = () => {
   const selectRef = useRef<HTMLSelectElement>(null)
   const textareaRef = useRef<HTMLInputElement>(null)
   const sora = useAppSelector((state) => state.soraContents.sora)
+  const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const datachannels = useAppSelector((state) => state.soraContents.datachannels)
   const handleSendMessage = (): void => {
     if (selectRef.current === null || textareaRef.current === null) {
       return
     }
     const label = selectRef.current.value
-    if (sora) {
+    if (sora && connectionStatus === 'connected') {
       sora.sendMessage(label, new TextEncoder().encode(textareaRef.current.value))
     }
   }

--- a/src/components/DevtoolsPane/CameraDeviceForm.tsx
+++ b/src/components/DevtoolsPane/CameraDeviceForm.tsx
@@ -8,9 +8,10 @@ import { TooltipFormCheck } from './TooltipFormCheck'
 
 export const CameraDeviceForm: React.FC = () => {
   const cameraDevice = useAppSelector((state) => state.cameraDevice)
+  const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const sora = useAppSelector((state) => state.soraContents.sora)
   const video = useAppSelector((state) => state.video)
-  const disabled = !(sora ? sora.video : video)
+  const disabled = !(sora && connectionStatus === 'connected' ? sora.video : video)
   const dispatch = useAppDispatch()
   const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setCameraDevice(event.target.checked))

--- a/src/components/DevtoolsPane/MicDeviceForm.tsx
+++ b/src/components/DevtoolsPane/MicDeviceForm.tsx
@@ -8,9 +8,10 @@ import { TooltipFormCheck } from './TooltipFormCheck'
 
 export const MicDeviceForm: React.FC = () => {
   const micDevice = useAppSelector((state) => state.micDevice)
+  const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const sora = useAppSelector((state) => state.soraContents.sora)
   const audio = useAppSelector((state) => state.audio)
-  const disabled = !(sora ? sora.audio : audio)
+  const disabled = !(sora && connectionStatus === 'connected' ? sora.audio : audio)
   const dispatch = useAppDispatch()
   const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setMicDevice(event.target.checked))

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -8,6 +8,7 @@ import { DebugButton } from './DebugButton'
 import { DownloadReportButton } from './DownloadReportButton'
 
 export const Header: React.FC = () => {
+  const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const sora = useAppSelector((state) => state.soraContents.sora)
   return (
     <header>
@@ -20,7 +21,7 @@ export const Header: React.FC = () => {
             <Nav>
               <Navbar.Text className="py-0 my-1 mx-1">
                 <p className="navbar-signaling-url border rounded">
-                  {sora ? sora.connectedSignalingUrl : '未接続'}
+                  {sora && connectionStatus === 'connected' ? sora.connectedSignalingUrl : '未接続'}
                 </p>
               </Navbar.Text>
               <Navbar.Text className="py-0 my-1 mx-1">


### PR DESCRIPTION
### 変更履歴

- [CHANGE] `Session ID` と自身の  `Connection ID` `Client ID` の表示を `type: notify` の `connection.created` を受け取ったタイミングでの表示に変更する
  - この変更に伴い、Sora Devtools の Sora 接続状態の確認は state の `soraContents.connectionStatus` の値の確認も追加する
  - @tnamao
