### PR TITLE
Feature/display remote client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] 受信している接続のクライアント ID の表示に対応する
+  - `notify` で受け取ったクライアント ID を表示に使用するため、state の `soraContents.remoteMediaStream` を `soraContents.remoteClient` に変更し、MediaStream の他に `connectionId` と `client_id` を保持できる型に変更する
+  - この変更に伴ってリモートの `MediaStream` を使用した関数、変数の名前を `Client` に変更する
+  - @tnamao
 - [CHANGE] `Session ID` と自身の  `Connection ID` `Client ID` の表示を `type: notify` の `connection.created` を受け取ったタイミングでの表示に変更する
   - この変更に伴い、Sora Devtools の Sora 接続状態の確認は state の `soraContents.connectionStatus` の値の確認も追加する
   - @tnamao

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -18,6 +18,7 @@ import type {
   LogMessage,
   NotifyMessage,
   PushMessage,
+  RemoteClient,
   SignalingMessage,
   SoraDevtoolsState,
   TimelineMessage,
@@ -80,7 +81,7 @@ const initialState: SoraDevtoolsState = {
     clientId: null,
     sessionId: null,
     localMediaStream: null,
-    remoteMediaStreams: [],
+    remoteClients: [],
     prevStatsReport: [],
     statsReport: [],
     datachannels: [],
@@ -412,21 +413,31 @@ export const slice = createSlice({
       }
       state.soraContents.localMediaStream = action.payload
     },
-    setRemoteMediaStream: (state, action: PayloadAction<MediaStream>) => {
-      state.soraContents.remoteMediaStreams.push(action.payload)
+    setRemoteClient: (state, action: PayloadAction<RemoteClient>) => {
+      state.soraContents.remoteClients.push(action.payload)
+    },
+    setSoraRemoteClientId: (
+      state,
+      action: PayloadAction<{ connectionId: string; clientId: string }>,
+    ) => {
+      for (const client of state.soraContents.remoteClients) {
+        if (client.connectionId === action.payload.connectionId) {
+          client.clientId = action.payload.clientId
+        }
+      }
     },
     setStatsReport: (state, action: PayloadAction<RTCStats[]>) => {
       state.soraContents.prevStatsReport = state.soraContents.statsReport
       state.soraContents.statsReport = action.payload
     },
-    removeRemoteMediaStream: (state, action: PayloadAction<string>) => {
-      const remoteMediaStreams = state.soraContents.remoteMediaStreams.filter(
-        (stream) => stream.id !== action.payload,
+    removeRemoteClient: (state, action: PayloadAction<string>) => {
+      const remoteClients = state.soraContents.remoteClients.filter(
+        (client) => client.connectionId !== action.payload,
       )
-      state.soraContents.remoteMediaStreams = remoteMediaStreams
+      state.soraContents.remoteClients = remoteClients
     },
-    removeAllRemoteMediaStreams: (state) => {
-      state.soraContents.remoteMediaStreams = []
+    removeAllRemoteClients: (state) => {
+      state.soraContents.remoteClients = []
     },
     setAudioInputDevices: (state, action: PayloadAction<MediaDeviceInfo[]>) => {
       state.audioInputDevices = action.payload

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -14,7 +14,7 @@ export const store = configureStore({
         ignoredActions: [
           'soraDevtools/setSora',
           'soraDevtools/setLocalMediaStream',
-          'soraDevtools/setRemoteMediaStream',
+          'soraDevtools/setRemoteClient',
           'soraDevtools/setFakeContentsGainNode',
           'soraDevtools/setDataChannelMessage',
         ],

--- a/src/components/Video/RemoteVideos.tsx
+++ b/src/components/Video/RemoteVideos.tsx
@@ -2,7 +2,7 @@ import type React from 'react'
 import { useState } from 'react'
 
 import { useAppSelector } from '@/app/hooks'
-import type { RTCMediaStreamTrackStats } from '@/types'
+import type { RTCMediaStreamTrackStats, RemoteClient } from '@/types'
 
 import { ConnectionStatusBar } from './ConnectionStatusBar'
 import { JitterButter } from './JitterBuffer'
@@ -85,7 +85,8 @@ const MediaStreamStatsReport: React.FC<{ stream: MediaStream }> = (props) => {
   )
 }
 
-const RemoteVideo: React.FC<{ stream: MediaStream }> = (props) => {
+const RemoteVideo: React.FC<{ client: RemoteClient }> = ({ client }) => {
+  const { mediaStream, connectionId, clientId } = client
   const [height, setHeight] = useState<number>(0)
   const audioOutput = useAppSelector((state) => state.audioOutput)
   const displayResolution = useAppSelector((state) => state.displayResolution)
@@ -96,37 +97,28 @@ const RemoteVideo: React.FC<{ stream: MediaStream }> = (props) => {
   const mute = useAppSelector((state) => state.mute)
   const simulcast = useAppSelector((state) => state.simulcast)
   const spotlight = useAppSelector((state) => state.spotlight)
-  const focused = props.stream.id && focusedSpotlightConnectionIds[props.stream.id]
+  const focused = connectionId && focusedSpotlightConnectionIds[connectionId]
   return (
     <div className="col-auto">
       <div className="video-status">
         <div className="d-flex align-items-center mb-1 video-status-inner">
-          <ConnectionStatusBar connectionId={props.stream.id} />
-          <JitterButter type="audio" stream={props.stream} />
-          <JitterButter type="video" stream={props.stream} />
+          <ConnectionStatusBar connectionId={connectionId} clientId={clientId} />
+          <JitterButter type="audio" stream={mediaStream} />
+          <JitterButter type="video" stream={mediaStream} />
         </div>
         <div className="d-flex align-items-center mb-1 video-status-inner">
           {spotlight !== 'true' && multistream === 'true' && simulcast === 'true' ? (
             <>
-              <RequestRtpStreamBySendConnectionIdButton
-                rid="r0"
-                sendConnectionId={props.stream.id}
-              />
-              <RequestRtpStreamBySendConnectionIdButton
-                rid="r1"
-                sendConnectionId={props.stream.id}
-              />
-              <RequestRtpStreamBySendConnectionIdButton
-                rid="r2"
-                sendConnectionId={props.stream.id}
-              />
-              <ResetRtpStreamBySendConnectionIdButton sendConnectionId={props.stream.id} />
+              <RequestRtpStreamBySendConnectionIdButton rid="r0" sendConnectionId={connectionId} />
+              <RequestRtpStreamBySendConnectionIdButton rid="r1" sendConnectionId={connectionId} />
+              <RequestRtpStreamBySendConnectionIdButton rid="r2" sendConnectionId={connectionId} />
+              <ResetRtpStreamBySendConnectionIdButton sendConnectionId={connectionId} />
             </>
           ) : null}
           {spotlight === 'true' && multistream === 'true' && simulcast === 'true' ? (
             <>
-              <RequestSpotlightRidBySendConnectionIdButton sendConnectionId={props.stream.id} />
-              <ResetSpotlightRidBySendConnectionIdButton sendConnectionId={props.stream.id} />
+              <RequestSpotlightRidBySendConnectionIdButton sendConnectionId={connectionId} />
+              <ResetSpotlightRidBySendConnectionIdButton sendConnectionId={connectionId} />
             </>
           ) : null}
         </div>
@@ -138,26 +130,26 @@ const RemoteVideo: React.FC<{ stream: MediaStream }> = (props) => {
           }`}
         >
           <Video
-            stream={props.stream}
+            stream={mediaStream}
             setHeight={setHeight}
             mute={mute}
             audioOutput={audioOutput}
             displayResolution={displayResolution}
           />
-          <VolumeVisualizer micDevice stream={props.stream} height={height} />
+          <VolumeVisualizer micDevice stream={mediaStream} height={height} />
         </div>
-        <MediaStreamStatsReport stream={props.stream} />
+        <MediaStreamStatsReport stream={mediaStream} />
       </div>
     </div>
   )
 }
 
 export const RemoteVideos: React.FC = () => {
-  const remoteMediaStreams = useAppSelector((state) => state.soraContents.remoteMediaStreams)
+  const remoteClients = useAppSelector((state) => state.soraContents.remoteClients)
   return (
     <div className="row my-2">
-      {remoteMediaStreams.map((mediaStream) => {
-        return <RemoteVideo key={mediaStream.id} stream={mediaStream} />
+      {remoteClients.map((client) => {
+        return <RemoteVideo key={client.connectionId} client={client} />
       })}
     </div>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,12 @@ import type {
   VIDEO_CONTENT_HINTS,
 } from '@/constants'
 
+export type RemoteClient = {
+  mediaStream: MediaStream
+  clientId: string | null
+  connectionId: string
+}
+
 export type SoraDevtoolsState = {
   alertMessages: AlertMessage[]
   audio: boolean
@@ -99,7 +105,7 @@ export type SoraDevtoolsState = {
     clientId: string | null
     sessionId: string | null
     localMediaStream: MediaStream | null
-    remoteMediaStreams: MediaStream[]
+    remoteClients: RemoteClient[]
     prevStatsReport: RTCStats[]
     statsReport: RTCStats[]
     datachannels: DataChannelConfiguration[]


### PR DESCRIPTION
### 変更履歴

- [ADD] 受信している接続のクライアント ID の表示に対応する
  - `notify` で受け取ったクライアント ID を表示に使用するため、state の `soraContents.remoteMediaStream` を `soraContents.remoteClient` に変更し、MediaStream の他に `connectionId` と `client_id` を保持できる型に変更する
  - この変更に伴ってリモートの `MediaStream` を使用した関数、変数の名前を `Client` に変更する
  - @tnamao


---

This pull request primarily focuses on improving the handling of remote connections within the application. The changes include the addition of a new `RemoteClient` type that holds more information about each connection, and the refactoring of various functions and components to use this new type. This results in a more robust and flexible system for managing remote connections. 

Here are the most important changes:

### Changes to the `RemoteClient` type:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR45-R50): Introduced a new `RemoteClient` type that includes `mediaStream`, `clientId`, and `connectionId` properties. This type provides a more comprehensive representation of a remote connection.

### Changes to the state management:

* [`src/app/slice.ts`](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eL83-R84): The application state was updated to store an array of `RemoteClient` objects instead of an array of `MediaStream` objects. This allows the application to keep track of more information about each remote connection. [[1]](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eL83-R84) [[2]](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eL415-R440)

### Changes to the handling of remote connections:

* [`src/app/actions.ts`](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R854-R882): Various functions were updated to use the new `RemoteClient` type. These changes include saving the `client_id` of existing remote clients upon connection, and updating the handling of `track`, `removetrack`, and `disconnect` events to work with `RemoteClient` objects. [[1]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R854-R882) [[2]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00L875-R905) [[3]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00L889-R938) [[4]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00L933-R968) [[5]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00L942-R978) [[6]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00L956-R991)

### Changes to the UI components:

* [`src/components/Video/RemoteVideos.tsx`](diffhunk://#diff-8ca6ce048034fc03dc12bc3eb4857dc25d234d8f3be29307255543e35f813ba3L5-R5): The `RemoteVideo` component was updated to accept a `RemoteClient` object as a prop instead of a `MediaStream` object. This allows the component to display more information about each remote connection. [[1]](diffhunk://#diff-8ca6ce048034fc03dc12bc3eb4857dc25d234d8f3be29307255543e35f813ba3L5-R5) [[2]](diffhunk://#diff-8ca6ce048034fc03dc12bc3eb4857dc25d234d8f3be29307255543e35f813ba3L88-R89) [[3]](diffhunk://#diff-8ca6ce048034fc03dc12bc3eb4857dc25d234d8f3be29307255543e35f813ba3L99-R121) [[4]](diffhunk://#diff-8ca6ce048034fc03dc12bc3eb4857dc25d234d8f3be29307255543e35f813ba3L141-R152)

### Other changes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R17): Documented the changes made in this pull request.
* [`src/app/store.ts`](diffhunk://#diff-efbc9c2c3c62a72fb9d047216d1c0ed4a8223e51ce11cbcbb30a7a0a6049d042L17-R17): Updated the list of ignored actions to include `setRemoteClient` instead of `setRemoteMediaStream`.