### PR TITLE
接続中の TURN URL の表示を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,13 @@
 
 ## develop
 
+- [CHANGE] ヘッダーの接続先 URL の表示の初期値を変更する
+  - `未接続` を `Signaling URL` `TURN URL` に変更する
+  - @tnamao
 - [ADD] ヘッダーに接続中の TURN URL を表示する
   - `local-candidate` の RTCStats に `url` が含まれる場合に表示する
   - `local-candidate` が複数存在する場合は、最初に取得できる `url` を表示する
-  - Firefox では `url` が含まれないため、表示されません
+  - `url` が取得できない場合は `不明` と表示する
   - @tnamao
 - [CHANGE] `.env.example` を `.env.template` に揃える
   - @voluntas

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+- [ADD] ヘッダーに接続中の TURN URL を表示する
+  - `local-candidate` の RTCStats に `url` が含まれる場合に表示する
+  - `local-candidate` が複数存在する場合は、最初に取得できる `url` を表示する
+  - Firefox では `url` が含まれないため、表示されません
+  - @tnamao
 - [CHANGE] `.env.example` を `.env.template` に揃える
   - @voluntas
 - [CHANGE] `resolution` `displayResolution` `frameRate` を任意の値を入力できるようにする

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -85,6 +85,7 @@ const initialState: SoraDevtoolsState = {
     prevStatsReport: [],
     statsReport: [],
     datachannels: [],
+    turnUrl: null,
   },
   ignoreDisconnectWebSocket: '',
   logMessages: [],
@@ -384,6 +385,9 @@ export const slice = createSlice({
     },
     setSoraClientId: (state, action: PayloadAction<string | null>) => {
       state.soraContents.clientId = action.payload
+    },
+    setSoraTurnUrl: (state, action: PayloadAction<string | null>) => {
+      state.soraContents.turnUrl = action.payload
     },
     setSoraConnectionStatus: (
       state,

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,6 +9,7 @@ import { DownloadReportButton } from './DownloadReportButton'
 
 export const Header: React.FC = () => {
   const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
+  const turnUrl = useAppSelector((state) => state.soraContents.turnUrl)
   const sora = useAppSelector((state) => state.soraContents.sora)
   return (
     <header>
@@ -24,6 +25,11 @@ export const Header: React.FC = () => {
                   {sora && connectionStatus === 'connected' ? sora.connectedSignalingUrl : '未接続'}
                 </p>
               </Navbar.Text>
+              {sora && connectionStatus === 'connected' && turnUrl !== null && (
+                <Navbar.Text className="py-0 my-1 mx-1">
+                  <p className="navbar-turn-url border rounded">{turnUrl}</p>
+                </Navbar.Text>
+              )}
               <Navbar.Text className="py-0 my-1 mx-1">
                 <DebugButton />
               </Navbar.Text>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -13,7 +13,7 @@ export const Header: React.FC = () => {
   const sora = useAppSelector((state) => state.soraContents.sora)
   return (
     <header>
-      <Navbar variant="dark" bg="sora" expand="md" fixed="top">
+      <Navbar variant="dark" bg="sora" expand="lg" fixed="top">
         <Container>
           <Navbar.Brand href="/">Sora DevTools</Navbar.Brand>
           <Navbar.Toggle aria-controls="navbar-collapse" />

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,6 +11,12 @@ export const Header: React.FC = () => {
   const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const turnUrl = useAppSelector((state) => state.soraContents.turnUrl)
   const sora = useAppSelector((state) => state.soraContents.sora)
+  const turnUrlLabel = (() => {
+    if (sora && connectionStatus === 'connected') {
+      return turnUrl !== null ? turnUrl : '不明'
+    }
+    return 'TURN URL'
+  })()
   return (
     <header>
       <Navbar variant="dark" bg="sora" expand="lg" fixed="top">
@@ -22,14 +28,14 @@ export const Header: React.FC = () => {
             <Nav>
               <Navbar.Text className="py-0 my-1 mx-1">
                 <p className="navbar-signaling-url border rounded">
-                  {sora && connectionStatus === 'connected' ? sora.connectedSignalingUrl : '未接続'}
+                  {sora && connectionStatus === 'connected'
+                    ? sora.connectedSignalingUrl
+                    : 'Signaling URL'}
                 </p>
               </Navbar.Text>
-              {sora && connectionStatus === 'connected' && turnUrl !== null && (
-                <Navbar.Text className="py-0 my-1 mx-1">
-                  <p className="navbar-turn-url border rounded">{turnUrl}</p>
-                </Navbar.Text>
-              )}
+              <Navbar.Text className="py-0 my-1 mx-1">
+                <p className="navbar-turn-url border rounded">{turnUrlLabel}</p>
+              </Navbar.Text>
               <Navbar.Text className="py-0 my-1 mx-1">
                 <DebugButton />
               </Navbar.Text>

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -90,6 +90,14 @@ video {
   white-space: nowrap;
 }
 
+.navbar-turn-url {
+  min-width: 250px;
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+  margin: 0;
+  white-space: nowrap;
+}
+
 .container {
   max-width: none;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,7 @@ export type SoraDevtoolsState = {
     prevStatsReport: RTCStats[]
     statsReport: RTCStats[]
     datachannels: DataChannelConfiguration[]
+    turnUrl: string | null
   }
   ignoreDisconnectWebSocket: (typeof IGNORE_DISCONNECT_WEBSOCKET)[number]
   logMessages: LogMessage[]
@@ -412,3 +413,8 @@ export type DownloadReport = {
 }
 
 export type RTCStatsCodec = RTCStats & RTCRtpCodecParameters
+
+// RTCStats.type === 'local-candidate' の型
+export type RTCIceLocalCandidateStats = RTCStats & {
+  url?: string
+}


### PR DESCRIPTION
### 変更履歴

- [CHANGE] ヘッダーの接続先 URL の表示の初期値を変更する
  - `未接続` を `Signaling URL` `TURN URL` に変更する
  - @tnamao
- [ADD] ヘッダーに接続中の TURN URL を表示する
  - `local-candidate` の RTCStats に `url` が含まれる場合に表示する
  - `local-candidate` が複数存在する場合は、最初に取得できる `url` を表示する
  - `url` が取得できない場合は `不明` と表示する
  - @tnamao

---

This pull request primarily introduces changes to display the TURN URL in the header when a connection is established. The changes also modify the default display text in the header when no connection is established. The changes span across several files, including `CHANGES.md`, `src/app/actions.ts`, `src/app/slice.ts`, `src/components/Header/index.tsx`, `src/pages/_app.css`, and `src/types.ts`.

Display Changes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R21): Updated the header's default display text from `未接続` to `Signaling URL` and `TURN URL`. Also, added functionality to display the TURN URL when a connection is established.
* [`src/components/Header/index.tsx`](diffhunk://#diff-b74d58497974281b6e8d776b73cf7610aca5082355bbb47d06e632f0c92cd1dfR12-R22): Modified the header component to include the TURN URL. The TURN URL is fetched from the state and displayed. If the TURN URL is not available, `不明` is displayed. [[1]](diffhunk://#diff-b74d58497974281b6e8d776b73cf7610aca5082355bbb47d06e632f0c92cd1dfR12-R22) [[2]](diffhunk://#diff-b74d58497974281b6e8d776b73cf7610aca5082355bbb47d06e632f0c92cd1dfL24-R38)

State and Action Changes:

* [`src/app/actions.ts`](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R12): Added a new action `setSoraTurnUrl` to update the TURN URL in the state. Also, updated the `setStatsReport` function to fetch the TURN URL from the `local-candidate` stats and dispatch the `setSoraTurnUrl` action. [[1]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R12) [[2]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R995) [[3]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R1115-R1132)
* [`src/app/slice.ts`](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eR88): Added a new state variable `turnUrl` to store the TURN URL. Also, added a reducer for the `setSoraTurnUrl` action to update the `turnUrl` in the state. [[1]](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eR88) [[2]](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eR389-R391)

Type Changes:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR109): Added a new type `RTCIceLocalCandidateStats` to represent the `local-candidate` stats. This type includes a `url` field to store the TURN URL. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR109) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR416-R420)

Style Changes:

* [`src/pages/_app.css`](diffhunk://#diff-8097d55beb8d9b6f3ef93380d990855533e42c160ba94f0930cfb49364228f28R93-R100): Added styles for the TURN URL display in the header.