### PR TITLE
音声ビットレートの選択肢に 384 kbps を追加する

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export const SPOTLIGHT = ['', 'true', 'false'] as const
 
 export const AUDIO_CODEC_TYPES = ['', 'OPUS'] as const
 
-export const AUDIO_BIT_RATES = ['', '8', '16', '24', '32', '64', '96', '128', '256'] as const
+export const AUDIO_BIT_RATES = ['', '8', '16', '24', '32', '64', '96', '128', '256', '384'] as const
 
 export const VIDEO_CODEC_TYPES = ['', 'VP8', 'VP9', 'AV1', 'H264', 'H265'] as const
 


### PR DESCRIPTION
# 変更履歴

- audioBitRate の選択に 384 kbps を追加しました [#1602](https://github.com/shiguredo/sora-oss-private/issues/1602) 