### PR TITLE
audioBitRate と videoBitRate を自由に設定可能に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,12 @@
 
 ## develop
 
+- [CHANGE] audioBitRate と videoBitRate を自由に設定できるようにする
+  - 自由入力にし、選択肢以外のビットレートでも Sora の接続パラメータとして使用できるようにする
+  - @tnamao
 - [CHANGE] index ページのサイマルキャストのリンクのうち `resolution` の値の指定に誤りがあったので修正する
   - `720p (1280x720)` を解像度のみの `1280x720` に修正する
+  - @tnamao
 - [ADD] 音声ビットレートの選択肢に 384 kbps を追加する
   - @blaue-fuchs
 

--- a/instructions.json
+++ b/instructions.json
@@ -33,7 +33,7 @@
     "description": "音声のコーデックタイプを指定します。"
   },
   "audioBitRate": {
-    "description": "音声のビットレートを指定します。"
+    "description": "音声のビットレートを指定します。\n6 ~ 510 kbps の範囲で指定できます。"
   },
   "video": {
     "description": "映像配信をするかどうかを指定します。"

--- a/instructions.json
+++ b/instructions.json
@@ -42,7 +42,7 @@
     "description": "映像のコーデックタイプを指定します。"
   },
   "videoBitRate": {
-    "description": "映像のビットレートを指定します。"
+    "description": "映像のビットレートを指定します。\n15,000 kbps までがサポート対象、それ以上のビットレートはサポート対象外です。"
   },
   "videoVP9Params": {
     "description": "映像のコーデックタイプに VP9 を指定した場合の設定を指定します。"

--- a/src/components/DevtoolsPane/AudioBitRateForm.tsx
+++ b/src/components/DevtoolsPane/AudioBitRateForm.tsx
@@ -1,10 +1,10 @@
 import type React from 'react'
-import { FormGroup, FormSelect } from 'react-bootstrap'
+import { Dropdown, DropdownButton, Form, FormGroup, InputGroup } from 'react-bootstrap'
 
 import { setAudioBitRate } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { AUDIO_BIT_RATES } from '@/constants'
-import { checkFormValue, isFormDisabled } from '@/utils'
+import { isFormDisabled } from '@/utils'
 
 import { TooltipFormLabel } from './TooltipFormLabel.tsx'
 
@@ -13,23 +13,40 @@ export const AudioBitRateForm: React.FC = () => {
   const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const disabled = isFormDisabled(connectionStatus)
   const dispatch = useAppDispatch()
-  const onChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-    if (checkFormValue(event.target.value, AUDIO_BIT_RATES)) {
-      dispatch(setAudioBitRate(event.target.value))
-    }
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    dispatch(setAudioBitRate(event.target.value))
   }
   return (
     <FormGroup className="form-inline" controlId="audioBitRate">
       <TooltipFormLabel kind="audioBitRate">audioBitRate:</TooltipFormLabel>
-      <FormSelect name="audioBitRate" value={audioBitRate} onChange={onChange} disabled={disabled}>
-        {AUDIO_BIT_RATES.map((value) => {
-          return (
-            <option key={value} value={value}>
-              {value === '' ? '未指定' : value}
-            </option>
-          )
-        })}
-      </FormSelect>
+      <InputGroup>
+        <Form.Control
+          className="form-audio-bit-rate"
+          type="text"
+          value={audioBitRate}
+          onChange={onChange}
+          placeholder="未指定"
+          disabled={disabled}
+        />
+        <DropdownButton
+          variant="outline-secondary form-template-dropdown"
+          title=""
+          align="end"
+          disabled={disabled}
+        >
+          {AUDIO_BIT_RATES.map((value) => {
+            return (
+              <Dropdown.Item
+                key={value}
+                as="button"
+                onClick={() => dispatch(setAudioBitRate(value))}
+              >
+                {value === '' ? '未指定' : value}
+              </Dropdown.Item>
+            )
+          })}
+        </DropdownButton>
+      </InputGroup>
     </FormGroup>
   )
 }

--- a/src/components/DevtoolsPane/VideoBitRateForm.tsx
+++ b/src/components/DevtoolsPane/VideoBitRateForm.tsx
@@ -1,10 +1,10 @@
 import type React from 'react'
-import { FormGroup, FormSelect } from 'react-bootstrap'
+import { Dropdown, DropdownButton, Form, FormGroup, InputGroup } from 'react-bootstrap'
 
 import { setVideoBitRate } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { VIDEO_BIT_RATES } from '@/constants'
-import { checkFormValue, isFormDisabled } from '@/utils'
+import { isFormDisabled } from '@/utils'
 
 import { TooltipFormLabel } from './TooltipFormLabel.tsx'
 
@@ -12,34 +12,53 @@ import { TooltipFormLabel } from './TooltipFormLabel.tsx'
 const DISPLAY_VIDEO_BIT_RATE: string[] = VIDEO_BIT_RATES.slice()
 DISPLAY_VIDEO_BIT_RATE.splice(VIDEO_BIT_RATES.indexOf('15000') + 1, 0, 'support-message')
 
+const dropdownItemLabel = (value: string) => {
+  if (value === 'support-message') {
+    return '以下はサポート外です'
+  }
+  return value === '' ? '未指定' : value
+}
+
 export const VideoBitRateForm: React.FC = () => {
   const videoBitRate = useAppSelector((state) => state.videoBitRate)
   const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const disabled = isFormDisabled(connectionStatus)
   const dispatch = useAppDispatch()
-  const onChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-    if (checkFormValue(event.target.value, VIDEO_BIT_RATES)) {
-      dispatch(setVideoBitRate(event.target.value))
-    }
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    dispatch(setVideoBitRate(event.target.value))
   }
   return (
     <FormGroup className="form-inline" controlId="videoBitRate">
       <TooltipFormLabel kind="videoBitRate">videoBitRate:</TooltipFormLabel>
-      <FormSelect name="videoBitRate" value={videoBitRate} onChange={onChange} disabled={disabled}>
-        {DISPLAY_VIDEO_BIT_RATE.map((value) => {
-          let text = value
-          if (value === '') {
-            text = '未指定'
-          } else if (value === 'support-message') {
-            text = '以下はサポート外です'
-          }
-          return (
-            <option key={value} value={value} disabled={value === 'support-message'}>
-              {text}
-            </option>
-          )
-        })}
-      </FormSelect>
+      <InputGroup>
+        <Form.Control
+          className="form-video-bit-rate"
+          type="text"
+          value={videoBitRate}
+          onChange={onChange}
+          placeholder="未指定"
+          disabled={disabled}
+        />
+        <DropdownButton
+          variant="outline-secondary form-template-dropdown"
+          title=""
+          align="end"
+          disabled={disabled}
+        >
+          {DISPLAY_VIDEO_BIT_RATE.map((value) => {
+            return (
+              <Dropdown.Item
+                key={value}
+                as="button"
+                onClick={() => dispatch(setVideoBitRate(value))}
+                disabled={value === 'support-message'}
+              >
+                {dropdownItemLabel(value)}
+              </Dropdown.Item>
+            )
+          })}
+        </DropdownButton>
+      </InputGroup>
     </FormGroup>
   )
 }

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -49,6 +49,8 @@ footer .btn {
   padding-bottom: 0.5rem;
 }
 
+.form-audio-bit-rate,
+.form-video-bit-rate,
 .form-resolution,
 .form-display-resolution {
   max-width: 130px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,6 @@ import type {
 
 import type {
   ASPECT_RATIO_TYPES,
-  AUDIO_BIT_RATES,
   AUDIO_CODEC_TYPES,
   AUDIO_CONTENT_HINTS,
   AUTO_GAIN_CONTROLS,
@@ -48,7 +47,7 @@ export type RemoteClient = {
 export type SoraDevtoolsState = {
   alertMessages: AlertMessage[]
   audio: boolean
-  audioBitRate: (typeof AUDIO_BIT_RATES)[number]
+  audioBitRate: string
   audioCodecType: (typeof AUDIO_CODEC_TYPES)[number]
   audioContentHint: (typeof AUDIO_CONTENT_HINTS)[number]
   audioInput: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ import type {
   SPOTLIGHT,
   SPOTLIGHT_FOCUS_RIDS,
   SPOTLIGHT_NUMBERS,
-  VIDEO_BIT_RATES,
   VIDEO_CODEC_TYPES,
   VIDEO_CONTENT_HINTS,
 } from '@/constants'
@@ -133,7 +132,7 @@ export type SoraDevtoolsState = {
   spotlightFocusRid: (typeof SPOTLIGHT_FOCUS_RIDS)[number]
   spotlightUnfocusRid: (typeof SPOTLIGHT_FOCUS_RIDS)[number]
   video: boolean
-  videoBitRate: (typeof VIDEO_BIT_RATES)[number]
+  videoBitRate: string
   videoCodecType: (typeof VIDEO_CODEC_TYPES)[number]
   videoContentHint: (typeof VIDEO_CONTENT_HINTS)[number]
   videoInput: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,6 @@ import type { ConnectionOptions } from 'sora-js-sdk'
 
 import {
   ASPECT_RATIO_TYPES,
-  AUDIO_BIT_RATES,
   AUDIO_CODEC_TYPES,
   AUDIO_CONTENT_HINTS,
   AUTO_GAIN_CONTROLS,
@@ -117,7 +116,7 @@ export function parseQueryString(): Partial<QueryStringParameters> {
   const result: Partial<QueryStringParameters> = {
     apiUrl: parseStringParameter(qs.apiUrl),
     audio: parseBooleanParameter(qs.audio),
-    audioBitRate: parseSpecifiedStringParameter(qs.audioBitRate, AUDIO_BIT_RATES),
+    audioBitRate: parseStringParameter(qs.audioBitRate),
     audioCodecType: parseSpecifiedStringParameter(qs.audioCodecType, AUDIO_CODEC_TYPES),
     audioStreamingLanguageCode: parseStringParameter(qs.audioStreamingLanguageCode),
     autoGainControl: parseSpecifiedStringParameter(qs.autoGainControl, AUTO_GAIN_CONTROLS),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,6 @@ import {
   SPOTLIGHT,
   SPOTLIGHT_FOCUS_RIDS,
   SPOTLIGHT_NUMBERS,
-  VIDEO_BIT_RATES,
   VIDEO_CODEC_TYPES,
   VIDEO_CONTENT_HINTS,
 } from './constants.ts'
@@ -156,7 +155,7 @@ export function parseQueryString(): Partial<QueryStringParameters> {
     ),
     resolution: parseStringParameter(qs.resolution),
     video: parseBooleanParameter(qs.video),
-    videoBitRate: parseSpecifiedStringParameter(qs.videoBitRate, VIDEO_BIT_RATES),
+    videoBitRate: parseStringParameter(qs.videoBitRate),
     videoCodecType: parseSpecifiedStringParameter(qs.videoCodecType, VIDEO_CODEC_TYPES),
     videoVP9Params: parseStringParameter(qs.videoVP9Params),
     videoH264Params: parseStringParameter(qs.videoH264Params),


### PR DESCRIPTION
### 変更履歴

- [CHANGE] audioBitRate と videoBitRate を自由に設定できるようにする
  - 自由入力にし、選択肢以外のビットレートでも Sora の接続パラメータとして使用できるようにする
  - devtools 内で入力値のバリデーションは行わず、実際に接続可能かどうかは Sora 側のパラメータチェックに依存します
  - @tnamao

---
This pull request introduces several changes to enhance the flexibility of setting audio and video bit rates and updates related forms and documentation accordingly. The most important changes include allowing free input for bit rates, updating the forms to support this functionality, and removing hardcoded bit rate constants from various files.

### Enhancements to Bit Rate Settings:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R19): Added the ability to freely set `audioBitRate` and `videoBitRate` as connection parameters, allowing values outside the predefined options.

### Documentation Updates:

* [`instructions.json`](diffhunk://#diff-d4a451ad2863e5577b7cc521ab817f447f4a7c53c11bf6281e7fc34511f35f2aL36-R36): Updated descriptions to reflect the new range of supported bit rates for audio (6 ~ 510 kbps) and video (up to 15,000 kbps). [[1]](diffhunk://#diff-d4a451ad2863e5577b7cc521ab817f447f4a7c53c11bf6281e7fc34511f35f2aL36-R36) [[2]](diffhunk://#diff-d4a451ad2863e5577b7cc521ab817f447f4a7c53c11bf6281e7fc34511f35f2aL45-R45)

### Form Updates:

* [`src/components/DevtoolsPane/AudioBitRateForm.tsx`](diffhunk://#diff-ff4077b3bcc1298c8d0114f28b1ab79f8b933b631f8f2915bbd985ed894dd496L2-R7): Replaced the select input with a text input and a dropdown to allow free input for audio bit rates. [[1]](diffhunk://#diff-ff4077b3bcc1298c8d0114f28b1ab79f8b933b631f8f2915bbd985ed894dd496L2-R7) [[2]](diffhunk://#diff-ff4077b3bcc1298c8d0114f28b1ab79f8b933b631f8f2915bbd985ed894dd496L16-R49)
* [`src/components/DevtoolsPane/VideoBitRateForm.tsx`](diffhunk://#diff-71d3a29ec3235a50027d6cb07f39785cfaeb1b899a27f997cf1c96ea9db32cb5L2-R61): Similar update as the audio form to support free input for video bit rates, including a custom message for unsupported bit rates.

### Codebase Simplification:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL15): Removed hardcoded bit rate constants and updated types to use strings instead. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL15) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL37) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL51-R49) [[4]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL137-R135)
* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L10): Removed references to hardcoded bit rate constants and updated parsing functions to accommodate the new free input format. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L10) [[2]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L32) [[3]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L120-R118) [[4]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L160-R158)