### PR TITLE
mp4Media 関連のバグ修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
     - Chrome / Edge のみで利用可能
     - B フレームを含んだ H.264 は正常に再生できない
   - @sile
+- [ADD] @shiguredo/mp4-media-stream (2024.1.2) を依存パッケージに追加する
+  - @sile
 - [CHANGE] audioBitRate と videoBitRate を自由に設定できるようにする
   - 自由入力にし、選択肢以外のビットレートでも Sora の接続パラメータとして使用できるようにする
   - @tnamao

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "2.3.0",
     "@shiguredo/light-adjustment": "2024.1.0",
-    "@shiguredo/mp4-media-stream": "2024.1.1",
+    "@shiguredo/mp4-media-stream": "2024.1.2",
     "@shiguredo/noise-suppression": "2022.4.2",
     "@shiguredo/virtual-background": "2023.2.0",
     "bootstrap": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "2.3.0",
     "@shiguredo/light-adjustment": "2024.1.0",
-    "@shiguredo/mp4-media-stream": "2024.1.0",
+    "@shiguredo/mp4-media-stream": "2024.1.1",
     "@shiguredo/noise-suppression": "2022.4.2",
     "@shiguredo/virtual-background": "2023.2.0",
     "bootstrap": "5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2024.1.0
         version: 2024.1.0
       '@shiguredo/mp4-media-stream':
-        specifier: 2024.1.1
-        version: 2024.1.1
+        specifier: 2024.1.2
+        version: 2024.1.2
       '@shiguredo/noise-suppression':
         specifier: 2022.4.2
         version: 2022.4.2
@@ -678,8 +678,8 @@ packages:
   '@shiguredo/light-adjustment@2024.1.0':
     resolution: {integrity: sha512-s1kRIoC9RxLrymkz8YQiHo1ngUmzcMff8hVXgYGXeo5U4HUgToBJWbpT5JrITXZGSmAihRpMGk74YrlIcgHrow==}
 
-  '@shiguredo/mp4-media-stream@2024.1.1':
-    resolution: {integrity: sha512-kLdU0E39C9gF1p7S8xKOb2pqJIP3TaSRNyMKjw+X/+xNZsGL6CJ7DydRq/vGmwldRr/sG3s/c4NSzp3u/u8TcA==}
+  '@shiguredo/mp4-media-stream@2024.1.2':
+    resolution: {integrity: sha512-xL4MB3lpsnC5Yv/3e58dzJ0PHOdasWUONg2B33988UCCoNUnKA9Ph28Sm4day53WkdDy8xadfyxPwqTyyQAUZg==}
 
   '@shiguredo/noise-suppression@2022.4.2':
     resolution: {integrity: sha512-cgNgDcqiamc2VDpWYVjZXEIGwEio51QvKcdipf452gTESie1PR6rqZaKVwHxuABgsudKGq/1FrBlui9KCdFAtg==}
@@ -1907,7 +1907,7 @@ snapshots:
 
   '@shiguredo/light-adjustment@2024.1.0': {}
 
-  '@shiguredo/mp4-media-stream@2024.1.1': {}
+  '@shiguredo/mp4-media-stream@2024.1.2': {}
 
   '@shiguredo/noise-suppression@2022.4.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2024.1.0
         version: 2024.1.0
       '@shiguredo/mp4-media-stream':
-        specifier: 2024.1.0
-        version: 2024.1.0
+        specifier: 2024.1.1
+        version: 2024.1.1
       '@shiguredo/noise-suppression':
         specifier: 2022.4.2
         version: 2022.4.2
@@ -678,8 +678,8 @@ packages:
   '@shiguredo/light-adjustment@2024.1.0':
     resolution: {integrity: sha512-s1kRIoC9RxLrymkz8YQiHo1ngUmzcMff8hVXgYGXeo5U4HUgToBJWbpT5JrITXZGSmAihRpMGk74YrlIcgHrow==}
 
-  '@shiguredo/mp4-media-stream@2024.1.0':
-    resolution: {integrity: sha512-A0nZwzpvzP+yv8TdQDOWf4JTizRMrAQ7WV98Rp/VTEYrhvNtFmh3iHrBVI3hS7FsQguJIp6nXzN8vh1SMoBEGA==}
+  '@shiguredo/mp4-media-stream@2024.1.1':
+    resolution: {integrity: sha512-kLdU0E39C9gF1p7S8xKOb2pqJIP3TaSRNyMKjw+X/+xNZsGL6CJ7DydRq/vGmwldRr/sG3s/c4NSzp3u/u8TcA==}
 
   '@shiguredo/noise-suppression@2022.4.2':
     resolution: {integrity: sha512-cgNgDcqiamc2VDpWYVjZXEIGwEio51QvKcdipf452gTESie1PR6rqZaKVwHxuABgsudKGq/1FrBlui9KCdFAtg==}
@@ -1907,7 +1907,7 @@ snapshots:
 
   '@shiguredo/light-adjustment@2024.1.0': {}
 
-  '@shiguredo/mp4-media-stream@2024.1.0': {}
+  '@shiguredo/mp4-media-stream@2024.1.1': {}
 
   '@shiguredo/noise-suppression@2022.4.2':
     dependencies:

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -671,7 +671,11 @@ async function createMediaStream(
     )
     return [mediaStream, gainNode]
   }
-  if (state.mediaType === 'mp4Media' && state.mp4MediaStream !== null) {
+  if (state.mediaType === 'mp4Media') {
+    if (state.mp4MediaStream === null) {
+      throw new Error('No MP4 file has been selected')
+    }
+
     // 指定の MP4 を再生するための MediaStream を返す
     // DevTools ではいったん常に繰り返し再生にしておく
     return [state.mp4MediaStream.play({ repeat: true }), null]

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -289,7 +289,7 @@ export const slice = createSlice({
     setMediaStats: (state, action: PayloadAction<boolean>) => {
       state.mediaStats = action.payload
     },
-    setMp4MediaStream: (state, action: PayloadAction<Mp4MediaStream>) => {
+    setMp4MediaStream: (state, action: PayloadAction<Mp4MediaStream | null>) => {
       state.mp4MediaStream = action.payload
     },
     setNoiseSuppression: (state, action: PayloadAction<SoraDevtoolsState['noiseSuppression']>) => {

--- a/src/components/DevtoolsPane/Mp4FileForm.tsx
+++ b/src/components/DevtoolsPane/Mp4FileForm.tsx
@@ -21,16 +21,17 @@ export const Mp4FileForm: React.FC = () => {
       return
     }
 
-    // 以前の内容が残っていた場合に備えて事前に null を入れておく
-    dispatch(setMp4MediaStream(null))
-
     // MP4 ファイルをロードする
     try {
       const mp4MediaStream = await Mp4MediaStream.load(files[0])
       dispatch(setMp4MediaStream(mp4MediaStream))
     } catch (e) {
       // ロードに失敗したらファイル選択をクリアする
-      event.target.value = ""
+      event.target.value = ''
+
+      // 以前の内容が残っていた場合に備えて null を入れておく
+      dispatch(setMp4MediaStream(null))
+
       throw e
     }
   }

--- a/src/components/DevtoolsPane/Mp4FileForm.tsx
+++ b/src/components/DevtoolsPane/Mp4FileForm.tsx
@@ -41,7 +41,7 @@ export const Mp4FileForm: React.FC = () => {
   return (
     <FormGroup className="form-inline" controlId="mp4File">
       <TooltipFormLabel kind="mp4File">mp4File:</TooltipFormLabel>
-      <Form.Control type="file" disabled={disabled} onChange={onChange} />
+      <Form.Control type="file" accept="video/mp4" disabled={disabled} onChange={onChange} />
     </FormGroup>
   )
 }

--- a/src/components/DevtoolsPane/Mp4FileForm.tsx
+++ b/src/components/DevtoolsPane/Mp4FileForm.tsx
@@ -20,8 +20,19 @@ export const Mp4FileForm: React.FC = () => {
     if (files === null || files.length === 0) {
       return
     }
-    const mp4MediaStream = await Mp4MediaStream.load(files[0])
-    dispatch(setMp4MediaStream(mp4MediaStream))
+
+    // 以前の内容が残っていた場合に備えて事前に null を入れておく
+    dispatch(setMp4MediaStream(null))
+
+    // MP4 ファイルをロードする
+    try {
+      const mp4MediaStream = await Mp4MediaStream.load(files[0])
+      dispatch(setMp4MediaStream(mp4MediaStream))
+    } catch (e) {
+      // ロードに失敗したらファイル選択をクリアする
+      event.target.value = ""
+      throw e
+    }
   }
   if (mediaType !== 'mp4Media') {
     return null


### PR DESCRIPTION
mp4Media 関連の以下の二つの問題を修正しました:
- 音声のみの MP4 ファイルを選択すると配信時にエラーになっていた
  - mp4-media-stream 側のバグだったのため、その修正版パッケージを使うようにした
- mp4Media を選択していても、ファイルが未選択だったりロードエラーになっていると、getUserMedia に勝手にフォールバックするにフォールバックしていた
   - また、ファイルのロードに失敗した場合でも `mp4File` 要素の値が残ったままになっていて紛らわしかったので、失敗時にはクリアするようにした
   
Copilot Summary
------------------

This pull request includes several updates to dependencies and improvements to error handling for media streams. The most important changes involve updating the version of the `@shiguredo/mp4-media-stream` package and enhancing the error handling in the `createMediaStream` function.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R30): Updated the version of `@shiguredo/mp4-media-stream` from `2024.1.0` to `2024.1.2`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18-R19): Updated the `specifier` and `version` fields for `@shiguredo/mp4-media-stream` from `2024.1.0` to `2024.1.2` in both `importers` and `packages` sections. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18-R19) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL681-R682)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1910-R1910): Updated the `snapshots` section to reflect the new version `2024.1.2` for `@shiguredo/mp4-media-stream`.

Error handling improvements:

* [`src/app/actions.ts`](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00L674-R678): Enhanced the `createMediaStream` function to throw an error if no MP4 file has been selected when `state.mediaType` is `mp4Media`.