### PR TITLE
JSON 入力欄のコンポーネント化と JSON 入力欄への横展開

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,20 @@
 
 ## develop
 
-- [CHANGE] `forwardingFilter` `forwardingFilters` 入力欄の機能追加
+- [CHANGE] JSON を入力する欄に機能を追加する
+  - 対象の項目は以下
+    - `metadata`
+    - `signalingNotifyMetadata`
+    - `forwardingFilters`
+    - `forwardingFilter`
+    - `dataChannels`
+    - `videoVP9Params`
+    - `videoAV1Params`
+    - `videoH264Params`
+    - `videoH265Params`
   - JSON の整形を行う `pretty format` ボタンを追加する
-  - 入力内容が JSON として正しくない場合に入力欄の border を赤くする
+    - 入力値が JSON として正しい時に有効になる
+  - 入力内容が JSON として正しくない場合に入力欄の枠線を赤くする
   - @tnamao
 - [ADD] forwardingFilters の入力項目を新規追加する
   - 既存の forwardingFilter も残しており、両方設定した場合はシグナリング時に両方のパラメータを送信する

--- a/src/components/DevtoolsPane/DataChannelsForm.tsx
+++ b/src/components/DevtoolsPane/DataChannelsForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Button, Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Button, Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setDataChannels, setEnabledDataChannels } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const DataChannelsForm: React.FC = () => {
@@ -30,9 +31,6 @@ export const DataChannelsForm: React.FC = () => {
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledDataChannels(event.target.checked))
   }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setDataChannels(event.target.value))
-  }
   return (
     <>
       <Row className="form-row">
@@ -52,27 +50,24 @@ export const DataChannelsForm: React.FC = () => {
       {enabledDataChannels ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline position-relative" controlId="dataChannels">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder={textareaPlaceholder}
-                value={dataChannels}
-                onChange={onChangeText}
-                rows={12}
-                cols={100}
-                disabled={disabled}
-              />
-              <Button
-                className="btn-load-template"
-                type="button"
-                variant="outline-secondary"
-                size="sm"
-                onClick={() => dispatch(setDataChannels(exampleJsonString))}
-              >
-                load template
-              </Button>
-            </FormGroup>
+            <JSONInputField
+              controlId="dataChannels"
+              placeholder={textareaPlaceholder}
+              value={dataChannels}
+              setValue={(value) => dispatch(setDataChannels(value))}
+              disabled={disabled}
+              rows={12}
+              extraControls={
+                <Button
+                  type="button"
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={() => dispatch(setDataChannels(exampleJsonString))}
+                >
+                  load template
+                </Button>
+              }
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/ForwardingFilterForm.tsx
+++ b/src/components/DevtoolsPane/ForwardingFilterForm.tsx
@@ -1,11 +1,11 @@
 import type React from 'react'
-import { Button, Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledForwardingFilter, setForwardingFilter } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
-import { useEffect, useState } from 'react'
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const ForwardingFilterForm: React.FC = () => {
@@ -14,37 +14,9 @@ export const ForwardingFilterForm: React.FC = () => {
   const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const disabled = isFormDisabled(connectionStatus)
   const dispatch = useAppDispatch()
-  const [invalidJsonString, setInvalidJsonString] = useState(false)
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledForwardingFilter(event.target.checked))
   }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setForwardingFilter(event.target.value))
-  }
-  const prettyFormat = (jsonString: string): void => {
-    if (jsonString === '') {
-      return
-    }
-    try {
-      const formated = JSON.stringify(JSON.parse(jsonString), null, 2)
-      dispatch(setForwardingFilter(formated))
-    } catch {
-      // JSON.parse に失敗した場合は何もしない
-    }
-  }
-  // JSON 構文のチェック
-  useEffect(() => {
-    if (forwardingFilter === '') {
-      setInvalidJsonString(false)
-      return
-    }
-    try {
-      JSON.parse(forwardingFilter)
-      setInvalidJsonString(false)
-    } catch {
-      setInvalidJsonString(true)
-    }
-  }, [forwardingFilter])
   return (
     <>
       <Row className="form-row">
@@ -64,27 +36,13 @@ export const ForwardingFilterForm: React.FC = () => {
       {enabledForwardingFilter ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline position-relative" controlId="forwardingFilter">
-              <FormControl
-                className={invalidJsonString ? 'flex-fill invalid-json' : 'flex-fill'}
-                as="textarea"
-                placeholder="forwardingFilterを指定"
-                value={forwardingFilter}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-              <Button
-                className="btn-pretty-format"
-                type="button"
-                variant="outline-secondary"
-                size="sm"
-                onClick={() => prettyFormat(forwardingFilter)}
-              >
-                pretty format
-              </Button>
-            </FormGroup>
+            <JSONInputField
+              controlId="forwardingFilter"
+              placeholder="forwardingFilterを指定"
+              value={forwardingFilter}
+              setValue={(value) => dispatch(setForwardingFilter(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/ForwardingFiltersForm.tsx
+++ b/src/components/DevtoolsPane/ForwardingFiltersForm.tsx
@@ -1,11 +1,11 @@
 import type React from 'react'
-import { Button, Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledForwardingFilters, setForwardingFilters } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
-import { useEffect, useState } from 'react'
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const ForwardingFiltersForm: React.FC = () => {
@@ -14,37 +14,9 @@ export const ForwardingFiltersForm: React.FC = () => {
   const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
   const disabled = isFormDisabled(connectionStatus)
   const dispatch = useAppDispatch()
-  const [invalidJsonString, setInvalidJsonString] = useState(false)
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledForwardingFilters(event.target.checked))
   }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setForwardingFilters(event.target.value))
-  }
-  const prettyFormat = (jsonString: string): void => {
-    if (jsonString === '') {
-      return
-    }
-    try {
-      const formated = JSON.stringify(JSON.parse(jsonString), null, 2)
-      dispatch(setForwardingFilters(formated))
-    } catch {
-      // JSON.parse に失敗した場合は何もしない
-    }
-  }
-  // JSON 構文のチェック
-  useEffect(() => {
-    if (forwardingFilters === '') {
-      setInvalidJsonString(false)
-      return
-    }
-    try {
-      JSON.parse(forwardingFilters)
-      setInvalidJsonString(false)
-    } catch {
-      setInvalidJsonString(true)
-    }
-  }, [forwardingFilters])
   return (
     <>
       <Row className="form-row">
@@ -64,27 +36,13 @@ export const ForwardingFiltersForm: React.FC = () => {
       {enabledForwardingFilters ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline position-relative" controlId="forwardingFilters">
-              <FormControl
-                className={invalidJsonString ? 'flex-fill invalid-json' : 'flex-fill'}
-                as="textarea"
-                placeholder="forwardingFiltersを指定"
-                value={forwardingFilters}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-              <Button
-                className="btn-pretty-format"
-                type="button"
-                variant="outline-secondary"
-                size="sm"
-                onClick={() => prettyFormat(forwardingFilters)}
-              >
-                pretty format
-              </Button>
-            </FormGroup>
+            <JSONInputField
+              controlId="forwardingFilters"
+              placeholder="forwardingFiltersを指定"
+              value={forwardingFilters}
+              setValue={(value) => dispatch(setForwardingFilters(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/JSONInputField.tsx
+++ b/src/components/DevtoolsPane/JSONInputField.tsx
@@ -20,6 +20,9 @@ type JSONInputFieldProps = {
   value: string
   disabled: boolean
   setValue: (value: string) => void
+  extraControls?: React.ReactNode
+  rows?: number
+  cols?: number
 }
 
 export const JSONInputField = ({
@@ -28,6 +31,9 @@ export const JSONInputField = ({
   placeholder,
   disabled,
   setValue,
+  extraControls,
+  rows,
+  cols,
 }: JSONInputFieldProps) => {
   const [invalidJsonString, setInvalidJsonString] = useState(false)
   const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -53,13 +59,13 @@ export const JSONInputField = ({
         placeholder={placeholder}
         value={value}
         onChange={onChangeText}
-        rows={10}
-        cols={100}
+        rows={rows || 10}
+        cols={cols || 100}
         disabled={disabled}
       />
       <div className="json-input-textarea-overlay">
+        {extraControls}
         <Button
-          className="btn-pretty-format"
           type="button"
           variant="outline-secondary"
           size="sm"

--- a/src/components/DevtoolsPane/JSONInputField.tsx
+++ b/src/components/DevtoolsPane/JSONInputField.tsx
@@ -1,0 +1,74 @@
+import type React from 'react'
+import { useEffect, useState } from 'react'
+import { Button, FormControl, FormGroup } from 'react-bootstrap'
+
+const prettyFormat = (jsonString: string, setValue: (value: string) => void): void => {
+  if (jsonString === '') {
+    return
+  }
+  try {
+    const formated = JSON.stringify(JSON.parse(jsonString), null, 2)
+    setValue(formated)
+  } catch {
+    // JSON.parse に失敗した場合は何もしない
+  }
+}
+
+type JSONInputFieldProps = {
+  controlId: string
+  placeholder: string
+  value: string
+  disabled: boolean
+  setValue: (value: string) => void
+}
+
+export const JSONInputField = ({
+  value,
+  controlId,
+  placeholder,
+  disabled,
+  setValue,
+}: JSONInputFieldProps) => {
+  const [invalidJsonString, setInvalidJsonString] = useState(false)
+  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setValue(event.target.value)
+  }
+  useEffect(() => {
+    if (value === '') {
+      setInvalidJsonString(false)
+      return
+    }
+    try {
+      JSON.parse(value)
+      setInvalidJsonString(false)
+    } catch {
+      setInvalidJsonString(true)
+    }
+  }, [value])
+  return (
+    <FormGroup className="form-inline position-relative" controlId={controlId}>
+      <FormControl
+        className={invalidJsonString ? 'flex-fill invalid-json' : 'flex-fill'}
+        as="textarea"
+        placeholder={placeholder}
+        value={value}
+        onChange={onChangeText}
+        rows={10}
+        cols={100}
+        disabled={disabled}
+      />
+      <div className="json-input-textarea-overlay">
+        <Button
+          className="btn-pretty-format"
+          type="button"
+          variant="outline-secondary"
+          size="sm"
+          onClick={() => prettyFormat(value, setValue)}
+          disabled={invalidJsonString}
+        >
+          pretty format
+        </Button>
+      </div>
+    </FormGroup>
+  )
+}

--- a/src/components/DevtoolsPane/MetadataForm.tsx
+++ b/src/components/DevtoolsPane/MetadataForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledMetadata, setMetadata } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const MetadataForm: React.FC = () => {
@@ -15,9 +16,6 @@ export const MetadataForm: React.FC = () => {
   const dispatch = useAppDispatch()
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledMetadata(event.target.checked))
-  }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setMetadata(event.target.value))
   }
   return (
     <>
@@ -38,18 +36,13 @@ export const MetadataForm: React.FC = () => {
       {enabledMetadata ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline" controlId="metadata">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder="Metadataを指定"
-                value={metadata}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-            </FormGroup>
+            <JSONInputField
+              controlId="metadata"
+              placeholder="Metadataを指定"
+              value={metadata}
+              setValue={(value) => dispatch(setMetadata(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/SignalingNotifyMetadataForm.tsx
+++ b/src/components/DevtoolsPane/SignalingNotifyMetadataForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledSignalingNotifyMetadata, setSignalingNotifyMetadata } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const SignalingNotifyMetadataForm: React.FC = () => {
@@ -17,9 +18,6 @@ export const SignalingNotifyMetadataForm: React.FC = () => {
   const dispatch = useAppDispatch()
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledSignalingNotifyMetadata(event.target.checked))
-  }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setSignalingNotifyMetadata(event.target.value))
   }
   return (
     <>
@@ -40,18 +38,13 @@ export const SignalingNotifyMetadataForm: React.FC = () => {
       {enabledSignalingNotifyMetadata ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline" controlId="signalingNotifyMetadata">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder="signalingNotifyMetadataを指定"
-                value={signalingNotifyMetadata}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-            </FormGroup>
+            <JSONInputField
+              controlId="signalingNotifyMetadata"
+              placeholder="signalingNotifyMetadataを指定"
+              value={signalingNotifyMetadata}
+              setValue={(value) => dispatch(setSignalingNotifyMetadata(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/VideoAV1ParamsForm.tsx
+++ b/src/components/DevtoolsPane/VideoAV1ParamsForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledVideoAV1Params, setVideoAV1Params } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const VideoAV1ParamsForm: React.FC = () => {
@@ -15,9 +16,6 @@ export const VideoAV1ParamsForm: React.FC = () => {
   const dispatch = useAppDispatch()
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledVideoAV1Params(event.target.checked))
-  }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setVideoAV1Params(event.target.value))
   }
   return (
     <>
@@ -38,18 +36,13 @@ export const VideoAV1ParamsForm: React.FC = () => {
       {enabledVideoAV1Params ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline" controlId="videoAV1Params">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder="videoAV1Paramsを指定"
-                value={videoAV1Params}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-            </FormGroup>
+            <JSONInputField
+              controlId="videoAV1Params"
+              placeholder="videoAV1Paramsを指定"
+              value={videoAV1Params}
+              setValue={(value) => dispatch(setVideoAV1Params(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/VideoH264ParamsForm.tsx
+++ b/src/components/DevtoolsPane/VideoH264ParamsForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledVideoH264Params, setVideoH264Params } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const VideoH264ParamsForm: React.FC = () => {
@@ -15,9 +16,6 @@ export const VideoH264ParamsForm: React.FC = () => {
   const dispatch = useAppDispatch()
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledVideoH264Params(event.target.checked))
-  }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setVideoH264Params(event.target.value))
   }
   return (
     <>
@@ -38,18 +36,13 @@ export const VideoH264ParamsForm: React.FC = () => {
       {enabledVideoH264Params ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline" controlId="videoH264Params">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder="videoH264Paramsを指定"
-                value={videoH264Params}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-            </FormGroup>
+            <JSONInputField
+              controlId="videoH264Params"
+              placeholder="videoH264Paramsを指定"
+              value={videoH264Params}
+              setValue={(value) => dispatch(setVideoH264Params(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/VideoH265ParamsForm.tsx
+++ b/src/components/DevtoolsPane/VideoH265ParamsForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledVideoH265Params, setVideoH265Params } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const VideoH265ParamsForm: React.FC = () => {
@@ -15,9 +16,6 @@ export const VideoH265ParamsForm: React.FC = () => {
   const dispatch = useAppDispatch()
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledVideoH265Params(event.target.checked))
-  }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setVideoH265Params(event.target.value))
   }
   return (
     <>
@@ -38,18 +36,13 @@ export const VideoH265ParamsForm: React.FC = () => {
       {enabledVideoH265Params ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline" controlId="videoH265Params">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder="videoH265Paramsを指定"
-                value={videoH265Params}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-            </FormGroup>
+            <JSONInputField
+              controlId="videoH265Params"
+              placeholder="videoH265Paramsを指定"
+              value={videoH265Params}
+              setValue={(value) => dispatch(setVideoH265Params(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/components/DevtoolsPane/VideoVP9ParamsForm.tsx
+++ b/src/components/DevtoolsPane/VideoVP9ParamsForm.tsx
@@ -1,10 +1,11 @@
 import type React from 'react'
-import { Col, FormControl, FormGroup, Row } from 'react-bootstrap'
+import { Col, FormGroup, Row } from 'react-bootstrap'
 
 import { setEnabledVideoVP9Params, setVideoVP9Params } from '@/app/actions'
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { isFormDisabled } from '@/utils'
 
+import { JSONInputField } from './JSONInputField.tsx'
 import { TooltipFormCheck } from './TooltipFormCheck.tsx'
 
 export const VideoVP9ParamsForm: React.FC = () => {
@@ -15,9 +16,6 @@ export const VideoVP9ParamsForm: React.FC = () => {
   const dispatch = useAppDispatch()
   const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setEnabledVideoVP9Params(event.target.checked))
-  }
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setVideoVP9Params(event.target.value))
   }
   return (
     <>
@@ -38,18 +36,13 @@ export const VideoVP9ParamsForm: React.FC = () => {
       {enabledVideoVP9Params ? (
         <Row className="form-row">
           <Col className="col-auto">
-            <FormGroup className="form-inline" controlId="videoVP9Params">
-              <FormControl
-                className="flex-fill"
-                as="textarea"
-                placeholder="videoVP9Paramsを指定"
-                value={videoVP9Params}
-                onChange={onChangeText}
-                rows={10}
-                cols={100}
-                disabled={disabled}
-              />
-            </FormGroup>
+            <JSONInputField
+              controlId="videoVP9Params"
+              placeholder="videoVP9Paramsを指定"
+              value={videoVP9Params}
+              setValue={(value) => dispatch(setVideoVP9Params(value))}
+              disabled={disabled}
+            />
           </Col>
         </Row>
       ) : null}

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -400,7 +400,7 @@ video {
   border-color: var(--bs-form-invalid-border-color);
 }
 
-.btn-pretty-format {
+.json-input-textarea-overlay {
   position: absolute;
   top: 10px;
   right: 10px;

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -392,6 +392,7 @@ video {
 
 .invalid-json {
   border-color: var(--bs-form-invalid-border-color);
+  border-width: 2px;
 }
 
 .invalid-json:focus {

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -390,12 +390,6 @@ video {
   transform: rotate(-180deg);
 }
 
-.btn-load-template {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-}
-
 .invalid-json {
   border-color: var(--bs-form-invalid-border-color);
 }

--- a/src/pages/_app.css
+++ b/src/pages/_app.css
@@ -394,10 +394,19 @@ video {
   border-color: var(--bs-form-invalid-border-color);
 }
 
+.invalid-json:focus {
+  border-color: var(--bs-form-invalid-border-color);
+}
+
 .json-input-textarea-overlay {
   position: absolute;
   top: 10px;
-  right: 10px;
+  right: 0;
+  display: flex;
+}
+
+.json-input-textarea-overlay button {
+  margin-right: 0.5rem;
 }
 
 .hr-form {


### PR DESCRIPTION
### 変更履歴

- [CHANGE] JSON を入力する欄に機能を追加する
  - 対象の項目は以下
    - `metadata`
    - `signalingNotifyMetadata`
    - `forwardingFilters`
    - `forwardingFilter`
    - `dataChannels`
    - `videoVP9Params`
    - `videoAV1Params`
    - `videoH264Params`
    - `videoH265Params`
  - JSON の整形を行う `pretty format` ボタンを追加する
    - 入力値が JSON として正しい時に有効になる
  - 入力内容が JSON として正しくない場合に入力欄の枠線を赤くする
  - @tnamao

---

This pull request introduces a new `JSONInputField` component and integrates it into various forms to enhance JSON input handling. The changes include replacing existing text areas with the new component and updating the `CHANGES.md` file to reflect these modifications.

### Enhancements to JSON Input Handling:

* **New Component Introduction:**
  * [`src/components/DevtoolsPane/JSONInputField.tsx`](diffhunk://#diff-4065d63fee3bdef43378ee7eecd729cf3279dc845a4aec40f45220f44f881df5R1-R80): Added a new `JSONInputField` component to handle JSON input with validation and formatting capabilities.

* **Integration of JSONInputField:**
  * [`src/components/DevtoolsPane/DataChannelsForm.tsx`](diffhunk://#diff-79679c77b38c1fd40ff2eb8baa0d6eb835bcdb4e3210b971aa8b46915ff301e9L2-R8): Replaced the existing text area with `JSONInputField` for the `dataChannels` input. [[1]](diffhunk://#diff-79679c77b38c1fd40ff2eb8baa0d6eb835bcdb4e3210b971aa8b46915ff301e9L2-R8) [[2]](diffhunk://#diff-79679c77b38c1fd40ff2eb8baa0d6eb835bcdb4e3210b971aa8b46915ff301e9L33-L35) [[3]](diffhunk://#diff-79679c77b38c1fd40ff2eb8baa0d6eb835bcdb4e3210b971aa8b46915ff301e9L55-R70)
  * [`src/components/DevtoolsPane/ForwardingFilterForm.tsx`](diffhunk://#diff-fa330775cb58954bf350d6cd28e4fa7a370cfe555d684292de804796fb657c51L2-R8): Integrated `JSONInputField` for the `forwardingFilter` input. [[1]](diffhunk://#diff-fa330775cb58954bf350d6cd28e4fa7a370cfe555d684292de804796fb657c51L2-R8) [[2]](diffhunk://#diff-fa330775cb58954bf350d6cd28e4fa7a370cfe555d684292de804796fb657c51L17-L47) [[3]](diffhunk://#diff-fa330775cb58954bf350d6cd28e4fa7a370cfe555d684292de804796fb657c51L67-L87)
  * [`src/components/DevtoolsPane/ForwardingFiltersForm.tsx`](diffhunk://#diff-bef44806b42b1b3199b9188eab1d1697ebf65328dedad8772c1e238ab1d9531bL2-R8): Applied `JSONInputField` for the `forwardingFilters` input. [[1]](diffhunk://#diff-bef44806b42b1b3199b9188eab1d1697ebf65328dedad8772c1e238ab1d9531bL2-R8) [[2]](diffhunk://#diff-bef44806b42b1b3199b9188eab1d1697ebf65328dedad8772c1e238ab1d9531bL17-L47) [[3]](diffhunk://#diff-bef44806b42b1b3199b9188eab1d1697ebf65328dedad8772c1e238ab1d9531bL67-L87)
  * [`src/components/DevtoolsPane/MetadataForm.tsx`](diffhunk://#diff-e4249114914bd180c243059947f5391aad81c5046c20c5a886a912493c49cb8dL2-R8): Updated to use `JSONInputField` for the `metadata` input. [[1]](diffhunk://#diff-e4249114914bd180c243059947f5391aad81c5046c20c5a886a912493c49cb8dL2-R8) [[2]](diffhunk://#diff-e4249114914bd180c243059947f5391aad81c5046c20c5a886a912493c49cb8dL19-L21) [[3]](diffhunk://#diff-e4249114914bd180c243059947f5391aad81c5046c20c5a886a912493c49cb8dL41-L52)
  * [`src/components/DevtoolsPane/SignalingNotifyMetadataForm.tsx`](diffhunk://#diff-83f798d3a291b0695379585f40230f4458a38000524313de262cbb892a1b13bbL2-R8): Switched to `JSONInputField` for the `signalingNotifyMetadata` input. [[1]](diffhunk://#diff-83f798d3a291b0695379585f40230f4458a38000524313de262cbb892a1b13bbL2-R8) [[2]](diffhunk://#diff-83f798d3a291b0695379585f40230f4458a38000524313de262cbb892a1b13bbL21-L23) [[3]](diffhunk://#diff-83f798d3a291b0695379585f40230f4458a38000524313de262cbb892a1b13bbL43-L54)
  * [`src/components/DevtoolsPane/VideoAV1ParamsForm.tsx`](diffhunk://#diff-398a53b5a274872d99bca95e5da04247bde5a1da140b1af85eb94b108e42d13aL2-R8): Replaced the text area with `JSONInputField` for the `videoAV1Params` input. [[1]](diffhunk://#diff-398a53b5a274872d99bca95e5da04247bde5a1da140b1af85eb94b108e42d13aL2-R8) [[2]](diffhunk://#diff-398a53b5a274872d99bca95e5da04247bde5a1da140b1af85eb94b108e42d13aL19-L21) [[3]](diffhunk://#diff-398a53b5a274872d99bca95e5da04247bde5a1da140b1af85eb94b108e42d13aL41-L52)
  * [`src/components/DevtoolsPane/VideoH264ParamsForm.tsx`](diffhunk://#diff-c304024bf1401e21658c494ae799cbb385257b3cce54816d688e91657f256ce2L2-R8): Implemented `JSONInputField` for the `videoH264Params` input. [[1]](diffhunk://#diff-c304024bf1401e21658c494ae799cbb385257b3cce54816d688e91657f256ce2L2-R8) [[2]](diffhunk://#diff-c304024bf1401e21658c494ae799cbb385257b3cce54816d688e91657f256ce2L19-L21) [[3]](diffhunk://#diff-c304024bf1401e21658c494ae799cbb385257b3cce54816d688e91657f256ce2L41-L52)

### Documentation Update:

* **CHANGES.md:**
  * Updated to reflect the addition of JSON input handling features and the introduction of the `pretty format` button.