### PR TITLE
Devtools の初期化処理に Service Worker の登録解除処理を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [ADD] Devtools の初期化処理に Service Worker の登録解除処理を追加する
+  - 以前 Sora Devtools 内で使用していた Service Worker の登録を解除するため
+  - @tnamao
 - [CHANGE] JSON を入力する欄に機能を追加する
   - 対象の項目は以下
     - `metadata`

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1605,6 +1605,15 @@ export const setMediaDevices = () => {
   }
 }
 
+export const unregisterServiceWorker = () => {
+  return async (_dispatch: Dispatch, _getState: () => SoraDevtoolsState): Promise<void> => {
+    const registrations = await navigator.serviceWorker.getRegistrations()
+    for (const registration of registrations) {
+      await registration.unregister()
+    }
+  }
+}
+
 // デバイスの変更時などに Sora との接続を維持したまま MediaStream のみ更新
 export const updateMediaStream = () => {
   return async (dispatch: Dispatch, getState: () => SoraDevtoolsState): Promise<void> => {

--- a/src/pages/devtools.tsx
+++ b/src/pages/devtools.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useEffect } from 'react'
 
-import { disconnectSora, setMediaDevices } from '@/app/actions'
+import { disconnectSora, setMediaDevices, unregisterServiceWorker } from '@/app/actions'
 import { setInitialParameter } from '@/app/actions'
 import { useAppDispatch } from '@/app/hooks'
 import { DebugPane } from '@/components/DebugPane'
@@ -16,6 +16,7 @@ const Devtools: React.FC = () => {
   useEffect(() => {
     dispatch(setInitialParameter())
     dispatch(setMediaDevices())
+    dispatch(unregisterServiceWorker())
     return () => {
       dispatch(disconnectSora())
     }


### PR DESCRIPTION
### 変更履歴

- [ADD] Devtools の初期化処理に Service Worker の登録解除処理を追加する
  - 以前 Sora Devtools 内で使用していた Service Worker の登録を解除するため
  - @tnamao

---

This pull request introduces a new feature to unregister Service Workers in the Sora Devtools and updates the initialization process accordingly. The changes include adding a new action to handle the unregistration and updating the relevant components to utilize this new action.

### New Feature: Unregister Service Workers

* **CHANGES.md**: Added an entry to document the addition of the Service Worker unregistration process in the Devtools initialization.

### Code Updates

* **`src/app/actions.ts`**: Introduced a new action `unregisterServiceWorker` that unregisters all Service Workers.
* **`src/pages/devtools.tsx`**: Imported the new `unregisterServiceWorker` action and dispatched it in the `useEffect` hook within the `Devtools` component. [[1]](diffhunk://#diff-518b8fa0c42ae27943c4bb754ea617cd5e90b95708031a8eb4658946e21841d2L4-R4) [[2]](diffhunk://#diff-518b8fa0c42ae27943c4bb754ea617cd5e90b95708031a8eb4658946e21841d2R19)