### PR TITLE
mp4-media-stream のバージョンを 2024.2.0 にあげる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
     - Chrome / Edge のみで利用可能
     - B フレームを含んだ H.264 は正常に再生できない
   - @sile
-- [ADD] @shiguredo/mp4-media-stream (2024.1.2) を依存パッケージに追加する
+- [ADD] @shiguredo/mp4-media-stream (2024.2.0) を依存パッケージに追加する
   - @sile
 - [CHANGE] audioBitRate と videoBitRate を自由に設定できるようにする
   - 自由入力にし、選択肢以外のビットレートでも Sora の接続パラメータとして使用できるようにする

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "2.3.0",
     "@shiguredo/light-adjustment": "2024.1.0",
-    "@shiguredo/mp4-media-stream": "2024.1.2",
+    "@shiguredo/mp4-media-stream": "2024.2.0",
     "@shiguredo/noise-suppression": "2022.4.2",
     "@shiguredo/virtual-background": "2023.2.0",
     "bootstrap": "5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2024.1.0
         version: 2024.1.0
       '@shiguredo/mp4-media-stream':
-        specifier: 2024.1.2
-        version: 2024.1.2
+        specifier: 2024.2.0
+        version: 2024.2.0
       '@shiguredo/noise-suppression':
         specifier: 2022.4.2
         version: 2022.4.2
@@ -680,8 +680,8 @@ packages:
   '@shiguredo/light-adjustment@2024.1.0':
     resolution: {integrity: sha512-s1kRIoC9RxLrymkz8YQiHo1ngUmzcMff8hVXgYGXeo5U4HUgToBJWbpT5JrITXZGSmAihRpMGk74YrlIcgHrow==}
 
-  '@shiguredo/mp4-media-stream@2024.1.2':
-    resolution: {integrity: sha512-xL4MB3lpsnC5Yv/3e58dzJ0PHOdasWUONg2B33988UCCoNUnKA9Ph28Sm4day53WkdDy8xadfyxPwqTyyQAUZg==}
+  '@shiguredo/mp4-media-stream@2024.2.0':
+    resolution: {integrity: sha512-rdgaPtYGv8/sUC6JEw0zPtTI+sSYBsN02RxTb/FFlXK+bRd2Stc6h5QpFOIqhsT8mwO5ebE1j4vBNk4NmlLJHg==}
 
   '@shiguredo/noise-suppression@2022.4.2':
     resolution: {integrity: sha512-cgNgDcqiamc2VDpWYVjZXEIGwEio51QvKcdipf452gTESie1PR6rqZaKVwHxuABgsudKGq/1FrBlui9KCdFAtg==}
@@ -1885,7 +1885,7 @@ snapshots:
 
   '@shiguredo/light-adjustment@2024.1.0': {}
 
-  '@shiguredo/mp4-media-stream@2024.1.2': {}
+  '@shiguredo/mp4-media-stream@2024.2.0': {}
 
   '@shiguredo/noise-suppression@2022.4.2':
     dependencies:

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -690,7 +690,7 @@ async function createMediaStream(
 
     // 指定の MP4 を再生するための MediaStream を返す
     // DevTools ではいったん常に繰り返し再生にしておく
-    return [state.mp4MediaStream.play({ repeat: true }), null]
+    return [await state.mp4MediaStream.play({ repeat: true }), null]
   }
   if (navigator.mediaDevices === undefined) {
     throw new Error('Failed to call getUserMedia. Make sure domain is secure')


### PR DESCRIPTION
This pull request includes several updates and improvements, primarily focusing on dependency updates and a minor code enhancement. The most important changes are listed below:

Dependency Updates:
* Updated `@shiguredo/mp4-media-stream` dependency from version `2024.1.2` to `2024.2.0` in `CHANGES.md` [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L42-R42) `package.json` [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R30) and `pnpm-lock.yaml` [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18-R19) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL683-R684) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1888-R1888).

Code Enhancement:
* Modified the `createMediaStream` function in `src/app/actions.ts` to use `await` for the `play` method, ensuring proper handling of the asynchronous operation.