### PR TITLE
オーバーレイしたボタンに背景色をつける

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] テキストボックスにオーバーレイしたボタンに背景色をつける
+  - `pretty format` と `load template` のオーバーレイボタン
+  - @tnamao
 - [CHANGE] multistream 項目を削除する
   - @voluntas
 - [CHANGE] 対応 Node.js のバージョンを 22.11 以上に上げる

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vite": "6.0.11",
     "vitest": "3.0.5"
   },
-  "packageManager": "pnpm@10.1.0",
+  "packageManager": "pnpm@10.0.0",
   "engines": {
     "node": ">=22.11"
   }

--- a/src/App.css
+++ b/src/App.css
@@ -410,6 +410,11 @@ video {
   margin-right: 0.5rem;
 }
 
+/* json-input-textarea-overlay 配下のボタンは disabled にしても透明度を無効にする */
+.json-input-textarea-overlay .btn.btn-light:disabled{
+  opacity: unset;
+}
+
 .hr-form {
   margin: 0.5rem 0 1rem 0;
 }

--- a/src/components/DevtoolsPane/DataChannelsForm.tsx
+++ b/src/components/DevtoolsPane/DataChannelsForm.tsx
@@ -60,7 +60,7 @@ export const DataChannelsForm: React.FC = () => {
               extraControls={
                 <Button
                   type="button"
-                  variant="outline-secondary"
+                  variant="light"
                   size="sm"
                   onClick={() => dispatch(setDataChannels(exampleJsonString))}
                 >

--- a/src/components/DevtoolsPane/JSONInputField.tsx
+++ b/src/components/DevtoolsPane/JSONInputField.tsx
@@ -67,7 +67,7 @@ export const JSONInputField = ({
         {extraControls}
         <Button
           type="button"
-          variant="outline-secondary"
+          variant="light"
           size="sm"
           onClick={() => prettyFormat(value, setValue)}
           disabled={invalidJsonString}


### PR DESCRIPTION
### 変更履歴

- [CHANGE] テキストボックスにオーバーレイしたボタンに背景色をつける
  - `pretty format` と `load template` のオーバーレイボタン
  - @tnamao

---

This pull request includes several changes to improve the styling and functionality of buttons within the application. The most important changes include adding background color to overlay buttons, modifying button variants, and ensuring disabled buttons do not have reduced opacity.

Styling and functionality improvements:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Added a background color to buttons overlaid on text boxes and updated the list of changes.
* [`src/App.css`](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972R413-R417): Ensured that buttons under `.json-input-textarea-overlay` do not have reduced opacity when disabled.

Button variant updates:

* [`src/components/DevtoolsPane/DataChannelsForm.tsx`](diffhunk://#diff-79679c77b38c1fd40ff2eb8baa0d6eb835bcdb4e3210b971aa8b46915ff301e9L63-R63): Changed the button variant from `outline-secondary` to `light` for consistency.
* [`src/components/DevtoolsPane/JSONInputField.tsx`](diffhunk://#diff-4065d63fee3bdef43378ee7eecd729cf3279dc845a4aec40f45220f44f881df5L70-R70): Updated the button variant from `outline-secondary` to `light` to match the new design.