### PR TITLE
forceStereoOutput オプションを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@
 - [CHANGE] `@shiguredo/light-adjustment` の依存を削除
   - @voluntas
   - @tnamao
+- [CHANGE] `forceStereoOutput` の設定を追加する
+  - 受信した音声を出力する際にステレオを強制する
+  - @tnamao
 
 ### misc
 

--- a/instructions.json
+++ b/instructions.json
@@ -56,6 +56,9 @@
   "videoAV1Params": {
     "description": "映像のコーデックタイプに AV1 を指定した場合の設定を指定します。"
   },
+  "forceStereoOutput": {
+    "description": "audioOutput をステレオに強制する。"
+  },
   "reconnect": {
     "description": "一度接続に成功したあとに意図しない切断があった場合に再接続するかどうかを指定します。"
   },

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -237,6 +237,9 @@ export const setInitialParameter = () => {
     if (qsParams.audioStreamingLanguageCode !== undefined) {
       dispatch(slice.actions.setAudioStreamingLanguageCode(qsParams.audioStreamingLanguageCode))
     }
+    if (qsParams.forceStereoOutput !== undefined) {
+      dispatch(slice.actions.setForceStereoOutput(qsParams.forceStereoOutput))
+    }
     dispatch(slice.actions.setInitialFakeContents())
     const {
       audioStreamingLanguageCode,
@@ -354,6 +357,7 @@ export const copyURL = () => {
         appendAudioVideoParams && state.videoAV1Params !== '' && state.enabledVideoAV1Params
           ? state.videoAV1Params
           : undefined,
+      forceStereoOutput: state.forceStereoOutput === true ? true : undefined,
       audioContentHint: state.audioContentHint !== '' ? state.audioContentHint : undefined,
       autoGainControl: state.autoGainControl !== '' ? state.autoGainControl : undefined,
       noiseSuppression: state.noiseSuppression !== '' ? state.noiseSuppression : undefined,
@@ -1897,6 +1901,7 @@ export const {
   setEnabledAudioStreamingLanguageCode,
   setFakeVolume,
   setFacingMode,
+  setForceStereoOutput,
   setFrameRate,
   setIgnoreDisconnectWebSocket,
   setLocalMediaStream,

--- a/src/app/slice.ts
+++ b/src/app/slice.ts
@@ -65,6 +65,7 @@ const initialState: SoraDevtoolsState = {
   enabledVideoAV1Params: false,
   audioStreamingLanguageCode: '',
   enabledAudioStreamingLanguageCode: false,
+  forceStereoOutput: false,
   fakeVolume: '0',
   fakeContents: {
     worker: null,
@@ -615,6 +616,12 @@ export const slice = createSlice({
       action: PayloadAction<SoraDevtoolsState['enabledAudioStreamingLanguageCode']>,
     ) => {
       state.enabledAudioStreamingLanguageCode = action.payload
+    },
+    setForceStereoOutput: (
+      state,
+      action: PayloadAction<SoraDevtoolsState['forceStereoOutput']>,
+    ) => {
+      state.forceStereoOutput = action.payload
     },
   },
 })

--- a/src/components/DevtoolsPane/ForceStereoOutputForm.tsx
+++ b/src/components/DevtoolsPane/ForceStereoOutputForm.tsx
@@ -1,0 +1,36 @@
+import type React from 'react'
+import { Col, FormGroup, Row } from 'react-bootstrap'
+
+import { setForceStereoOutput } from '@/app/actions'
+import { useAppDispatch, useAppSelector } from '@/app/hooks'
+import { isFormDisabled } from '@/utils'
+
+import { TooltipFormCheck } from './TooltipFormCheck.tsx'
+
+export const ForceStereoOutputForm: React.FC = () => {
+  const forceStereoOutput = useAppSelector((state) => state.forceStereoOutput)
+  const connectionStatus = useAppSelector((state) => state.soraContents.connectionStatus)
+  const disabled = isFormDisabled(connectionStatus)
+  const dispatch = useAppDispatch()
+  const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    dispatch(setForceStereoOutput(event.target.checked))
+  }
+  return (
+    <>
+      <Row className="form-row">
+        <Col className="col-auto">
+          <FormGroup className="form-inline" controlId="forceStereoOutput">
+            <TooltipFormCheck
+              kind="forceStereoOutput"
+              checked={forceStereoOutput}
+              onChange={onChangeSwitch}
+              disabled={disabled}
+            >
+              forceStereoOutput
+            </TooltipFormCheck>
+          </FormGroup>
+        </Col>
+      </Row>
+    </>
+  )
+}

--- a/src/components/DevtoolsPane/index.tsx
+++ b/src/components/DevtoolsPane/index.tsx
@@ -32,6 +32,7 @@ import { EchoCancellationForm } from './EchoCancellationForm.tsx'
 import { EchoCancellationTypeForm } from './EchoCancellationTypeForm.tsx'
 import { FacingModeForm } from './FacingModeForm.tsx'
 import { FakeVolumeForm } from './FakeVolumeForm.tsx'
+import { ForceStereoOutputForm } from './ForceStereoOutputForm.tsx'
 import { ForwardingFilterForm } from './ForwardingFilterForm.tsx'
 import { ForwardingFiltersForm } from './ForwardingFiltersForm.tsx'
 import { FrameRateForm } from './FrameRateForm.tsx'
@@ -240,12 +241,14 @@ const RowAdvancedSignalingOptions: React.FC = () => {
   const enabledVideoH264Params = useAppSelector((state) => state.enabledVideoH264Params)
   const enabledVideoH265Params = useAppSelector((state) => state.enabledVideoH265Params)
   const enabledVideoAV1Params = useAppSelector((state) => state.enabledVideoAV1Params)
+  const forceStereoOutput = useAppSelector((state) => state.forceStereoOutput)
   const enabledOptions = [
     enableAudioStreamingLanguageCode,
     enabledVideoVP9Params,
     enabledVideoH264Params,
     enabledVideoH265Params,
     enabledVideoAV1Params,
+    forceStereoOutput,
   ].some((e) => e)
   const linkClassNames = ['btn-collapse-options']
   if (collapsed) {
@@ -273,6 +276,7 @@ const RowAdvancedSignalingOptions: React.FC = () => {
           <VideoAV1ParamsForm />
           <VideoH264ParamsForm />
           <VideoH265ParamsForm />
+          <ForceStereoOutputForm />
         </div>
       </Collapse>
     </Row>

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export type SoraDevtoolsState = {
     gainNode: GainNode | null
   }
   fakeVolume: string
+  forceStereoOutput: boolean
   frameRate: string
   soraContents: {
     connectionStatus: (typeof CONNECTION_STATUS)[number]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -190,6 +190,7 @@ export function parseQueryString(searchParams: URLSearchParams): Partial<QuerySt
     videoH264Params: parseStringParameter(searchParams, 'videoH264Params'),
     videoH265Params: parseStringParameter(searchParams, 'videoH265Params'),
     videoAV1Params: parseStringParameter(searchParams, 'videoAV1Params'),
+    forceStereoOutput: parseBooleanParameter(searchParams, 'forceStereoOutput'),
     audioInput: parseStringParameter(searchParams, 'audioInput'),
     videoInput: parseStringParameter(searchParams, 'videoInput'),
     audioOutput: parseStringParameter(searchParams, 'audioOutput'),


### PR DESCRIPTION
### 変更履歴

- [CHANGE] `forceStereoOutput` の設定を追加する
  - 受信した音声を出力する際にステレオを強制する
  - @tnamao

---

This pull request introduces a new feature, `forceStereoOutput`, which allows audio output to be forced into stereo mode. The changes span multiple files, adding support for this feature across the codebase, including state management, query string parsing, and the user interface.

### Feature Addition: `forceStereoOutput`

#### Documentation Updates:
* Added a description of the `forceStereoOutput` setting in `CHANGES.md` and `instructions.json`. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R36-R38) [[2]](diffhunk://#diff-d4a451ad2863e5577b7cc521ab817f447f4a7c53c11bf6281e7fc34511f35f2aR59-R61)

#### State Management:
* Updated `src/app/slice.ts` to include `forceStereoOutput` in the application's state and added a corresponding action, `setForceStereoOutput`. [[1]](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eR68) [[2]](diffhunk://#diff-45bfbe03821b84e4fcd3d64b38e126de5d7b7a7a7537adf8a7088fb9c9c6194eR620-R625)
* Modified `src/app/actions.ts` to handle `forceStereoOutput` in query string parsing and URL copying logic. [[1]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R240-R242) [[2]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R360) [[3]](diffhunk://#diff-f614e3891e365664ae453d152ad62d608f4f5fa9708ead03b11241130e00af00R1904)
* Updated `src/types.ts` to include `forceStereoOutput` in the `SoraDevtoolsState` type definition.

#### User Interface:
* Added a new form component, `ForceStereoOutputForm`, in `src/components/DevtoolsPane/ForceStereoOutputForm.tsx` to allow users to toggle the `forceStereoOutput` setting.
* Integrated `ForceStereoOutputForm` into the advanced signaling options section in `src/components/DevtoolsPane/index.tsx`. [[1]](diffhunk://#diff-cf09cba5d632c655fb567bdf89c49838eef7232ce8c39a5712350c7d0f0815eeR35) [[2]](diffhunk://#diff-cf09cba5d632c655fb567bdf89c49838eef7232ce8c39a5712350c7d0f0815eeR244-R251) [[3]](diffhunk://#diff-cf09cba5d632c655fb567bdf89c49838eef7232ce8c39a5712350c7d0f0815eeR279)

#### Utility Updates:
* Enhanced query string parsing in `src/utils.ts` to support the `forceStereoOutput` parameter.