### PR TITLE
[WIP] SVC タブを追加して ScalabilityMode サポートチェック機能を実装する

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 VITE_ZUSTAND_DEVTOOLS=false
 VITE_SORA_SIGNALING_URL=ws://localhost:5000/signaling
 VITE_VIRTUAL_BACKGROUND_ASSETS_PATH=https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@latest/dist
+VITE_DEBUG_PANEL_SVC=false

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,7 @@
 VITE_ZUSTAND_DEVTOOLS=true
 VITE_SORA_SIGNALING_URL=ws://localhost:5000/signaling
 VITE_VIRTUAL_BACKGROUND_ASSETS_PATH=https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@latest/dist
+VITE_DEBUG_PANEL_SVC=false
 
 # テストに利用する Sora の Signaling URL を指定してください
 E2E_TEST_SORA_SIGNALING_URL=ws://127.0.0.1:5000/signaling

--- a/src/App.css
+++ b/src/App.css
@@ -14,13 +14,14 @@
   --color-bs-red: #dc3545;
 
   /* アクセシビリティカラー (Okabe-Ito パレット) */
-  --color-a11y-blue: #0072b2;
+  --color-a11y-black: #000000;
   --color-a11y-orange: #e69f00;
-  --color-a11y-green: #009e73;
+  --color-a11y-sky-blue: #56b4e9;
+  --color-a11y-bluish-green: #009e73;
   --color-a11y-yellow: #f0e442;
+  --color-a11y-blue: #0072b2;
   --color-a11y-vermilion: #d55e00;
-  --color-a11y-purple: #cc79a7;
-  --color-a11y-gray: #999999;
+  --color-a11y-reddish-purple: #cc79a7;
 }
 
 /* アプリ固有のユーティリティクラス */

--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,15 @@
   --color-bs-yellow: #ffc107;
   --color-bs-orange: #fd7e14;
   --color-bs-red: #dc3545;
+
+  /* アクセシビリティカラー (Okabe-Ito パレット) */
+  --color-a11y-blue: #0072b2;
+  --color-a11y-orange: #e69f00;
+  --color-a11y-green: #009e73;
+  --color-a11y-yellow: #f0e442;
+  --color-a11y-vermilion: #d55e00;
+  --color-a11y-purple: #cc79a7;
+  --color-a11y-gray: #999999;
 }
 
 /* アプリ固有のユーティリティクラス */

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -280,12 +280,12 @@ export function ScalabilityMode() {
           {checkState.value === "running" ? "Checking..." : "Check Support"}
         </button>
       </div>
-      <table className="w-full text-sm text-white border-collapse">
+      <table className="w-full text-sm text-white border-collapse table-fixed">
         <thead>
           <tr className="bg-dark">
-            <th className="border border-light p-1 text-left">Mode</th>
+            <th className="border border-light p-1 text-left w-36">Mode</th>
             {CODECS.map((codec) => (
-              <th key={codec} className="border border-light p-1 text-center">
+              <th key={codec} className="border border-light p-1 text-center w-16">
                 {codec}
               </th>
             ))}

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -187,9 +187,9 @@ function getStatusBgClass(status: CheckStatus): string {
     case "supported":
       return "bg-a11y-bluish-green";
     case "unsupported":
-      return "bg-a11y-orange";
-    case "error":
       return "bg-a11y-vermilion";
+    case "error":
+      return "bg-a11y-reddish-purple";
     default:
       return "bg-gray-600";
   }

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -185,7 +185,7 @@ function getStatusBgClass(status: CheckStatus): string {
     case "checking":
       return "bg-a11y-yellow text-black";
     case "supported":
-      return "bg-a11y-sky-blue";
+      return "bg-a11y-bluish-green";
     case "unsupported":
       return "bg-a11y-orange";
     case "error":

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -1,0 +1,278 @@
+import { useSignal } from "@preact/signals";
+
+import type { CustomHTMLCanvasElement } from "@/types";
+
+const CODECS = ["VP8", "VP9", "AV1", "H.264", "H.265"] as const;
+
+const SCALABILITY_MODES = [
+  // L系 (Inter-layer dependency: Yes)
+  "L1T1",
+  "L1T2",
+  "L1T3",
+  "L2T1",
+  "L2T2",
+  "L2T3",
+  "L3T1",
+  "L3T2",
+  "L3T3",
+  // Lh系 (1.5:1 ratio)
+  "L2T1h",
+  "L2T2h",
+  "L2T3h",
+  "L3T1h",
+  "L3T2h",
+  "L3T3h",
+  // S系 (Inter-layer dependency: No)
+  "S2T1",
+  "S2T2",
+  "S2T3",
+  "S2T1h",
+  "S2T2h",
+  "S2T3h",
+  "S3T1",
+  "S3T2",
+  "S3T3",
+  "S3T1h",
+  "S3T2h",
+  "S3T3h",
+  // KEY系
+  "L2T2_KEY",
+  "L2T2_KEY_SHIFT",
+  "L2T3_KEY",
+  "L2T3_KEY_SHIFT",
+  "L3T1_KEY",
+  "L3T2_KEY",
+  "L3T2_KEY_SHIFT",
+  "L3T3_KEY",
+  "L3T3_KEY_SHIFT",
+] as const;
+
+type CheckStatus = "unchecked" | "checking" | "supported" | "unsupported" | "error";
+type CheckState = "idle" | "running" | "completed";
+type ScalabilityModeResults = {
+  [codec: string]: {
+    [mode: string]: CheckStatus;
+  };
+};
+
+// コーデック名から MIME タイプへのマッピング
+function getCodecMimeType(codec: string): string {
+  switch (codec) {
+    case "VP8":
+      return "video/VP8";
+    case "VP9":
+      return "video/VP9";
+    case "AV1":
+      return "video/AV1";
+    case "H.264":
+      return "video/H264";
+    case "H.265":
+      return "video/H265";
+    default:
+      return `video/${codec}`;
+  }
+}
+
+// ダミービデオトラック作成関数
+function createDummyVideoTrack(): { track: MediaStreamTrack; cleanup: () => void } {
+  const canvas = document.createElement("canvas") as CustomHTMLCanvasElement;
+  canvas.width = 320;
+  canvas.height = 240;
+  const stream = canvas.captureStream(30);
+  const track = stream.getVideoTracks()[0];
+  return {
+    track,
+    cleanup: () => stream.getTracks().forEach((t) => t.stop()),
+  };
+}
+
+// RTCRtpSender.getCapabilities から指定コーデックを検索
+function findCodecCapability(codecName: string): RTCRtpCodec | null {
+  const capabilities = RTCRtpSender.getCapabilities("video");
+  if (!capabilities) {
+    return null;
+  }
+  const mimeType = getCodecMimeType(codecName).toLowerCase();
+  return capabilities.codecs.find((c) => c.mimeType.toLowerCase() === mimeType) ?? null;
+}
+
+// ローカル 1:1 接続を確立して ScalabilityMode サポートをチェックする関数
+async function checkScalabilityModeSupport(
+  codec: string,
+  mode: string,
+): Promise<{ supported: boolean; error?: string }> {
+  const codecCapability = findCodecCapability(codec);
+  if (!codecCapability) {
+    return { supported: false, error: `codec ${codec} not found in capabilities` };
+  }
+
+  const localPc = new RTCPeerConnection();
+  const remotePc = new RTCPeerConnection();
+  const { track, cleanup } = createDummyVideoTrack();
+
+  try {
+    // ICE candidate の交換
+    localPc.onicecandidate = (event) => {
+      if (event.candidate) {
+        void remotePc.addIceCandidate(event.candidate);
+      }
+    };
+    remotePc.onicecandidate = (event) => {
+      if (event.candidate) {
+        void localPc.addIceCandidate(event.candidate);
+      }
+    };
+
+    // localPc にトラックを追加
+    const sender = localPc.addTrack(track);
+
+    // コーデックを設定
+    const transceivers = localPc.getTransceivers();
+    const transceiver = transceivers.find((t) => t.sender === sender);
+    if (transceiver) {
+      transceiver.setCodecPreferences([codecCapability]);
+    }
+
+    // offer/answer の交換
+    const offer = await localPc.createOffer();
+    await localPc.setLocalDescription(offer);
+    await remotePc.setRemoteDescription(offer);
+
+    const answer = await remotePc.createAnswer();
+    await remotePc.setLocalDescription(answer);
+    await localPc.setRemoteDescription(answer);
+
+    // SDP ネゴシエーション完了後に scalabilityMode を設定
+    const parameters = sender.getParameters();
+    if (parameters.encodings.length === 0) {
+      parameters.encodings = [{}];
+    }
+
+    // @ts-ignore: scalabilityMode は標準には存在しないが、ブラウザによってはサポートしている
+    parameters.encodings[0].scalabilityMode = mode;
+
+    await sender.setParameters(parameters);
+    return { supported: true };
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    return { supported: false, error: errorMessage };
+  } finally {
+    localPc.close();
+    remotePc.close();
+    cleanup();
+  }
+}
+
+// ステータス表示コンポーネント
+function StatusCell({ status }: { status: CheckStatus }) {
+  switch (status) {
+    case "unchecked":
+      return <span className="text-gray-500">-</span>;
+    case "checking":
+      return <span className="text-yellow-500">...</span>;
+    case "supported":
+      return <span className="text-green-500">OK</span>;
+    case "unsupported":
+      return <span className="text-red-500">NG</span>;
+    case "error":
+      return <span className="text-orange-500">ERR</span>;
+    default:
+      return <span className="text-gray-500">-</span>;
+  }
+}
+
+// 結果の初期状態を生成
+function createInitialResults(): ScalabilityModeResults {
+  const results: ScalabilityModeResults = {};
+  for (const codec of CODECS) {
+    results[codec] = {};
+    for (const mode of SCALABILITY_MODES) {
+      results[codec][mode] = "unchecked";
+    }
+  }
+  return results;
+}
+
+// ScalabilityMode サポートチェックコンポーネント
+export function ScalabilityMode() {
+  const checkState = useSignal<CheckState>("idle");
+  const results = useSignal<ScalabilityModeResults>(createInitialResults());
+
+  const runCheck = async () => {
+    checkState.value = "running";
+    const newResults = createInitialResults();
+
+    // 全ての組み合わせを checking に設定
+    for (const codec of CODECS) {
+      for (const mode of SCALABILITY_MODES) {
+        newResults[codec][mode] = "checking";
+      }
+    }
+    results.value = { ...newResults };
+
+    // 各コーデックと scalabilityMode の組み合わせをチェック
+    for (const codec of CODECS) {
+      for (const mode of SCALABILITY_MODES) {
+        const result = await checkScalabilityModeSupport(codec, mode);
+        if (result.supported) {
+          newResults[codec][mode] = "supported";
+        } else if (result.error?.includes("not found")) {
+          newResults[codec][mode] = "error";
+        } else {
+          newResults[codec][mode] = "unsupported";
+        }
+        results.value = { ...newResults };
+      }
+    }
+
+    checkState.value = "completed";
+  };
+
+  return (
+    <div className="p-2">
+      <div className="flex justify-between items-center mb-2">
+        <span className="text-white font-bold">ScalabilityMode Support</span>
+        <button
+          type="button"
+          onClick={runCheck}
+          disabled={checkState.value === "running"}
+          className={`
+            px-3 py-1 text-sm rounded border
+            transition-colors duration-150
+            ${
+              checkState.value === "running"
+                ? "text-gray-400 bg-gray-600 border-gray-600 cursor-not-allowed"
+                : "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:border-blue-700 cursor-pointer"
+            }
+          `}
+        >
+          {checkState.value === "running" ? "Checking..." : "Check Support"}
+        </button>
+      </div>
+      <table className="w-full text-sm text-white border-collapse">
+        <thead>
+          <tr className="bg-dark">
+            <th className="border border-light p-1 text-left">Mode</th>
+            {CODECS.map((codec) => (
+              <th key={codec} className="border border-light p-1 text-center">
+                {codec}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {SCALABILITY_MODES.map((mode) => (
+            <tr key={mode}>
+              <td className="border border-light p-1 font-mono">{mode}</td>
+              {CODECS.map((codec) => (
+                <td key={`${codec}-${mode}`} className="border border-light p-1 text-center">
+                  <StatusCell status={results.value[codec][mode]} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -283,7 +283,7 @@ export function ScalabilityMode() {
       <table className="w-full text-sm text-white border-collapse table-fixed">
         <thead>
           <tr className="bg-dark">
-            <th className="border border-light p-1 text-left w-36">Mode</th>
+            <th className="border border-light p-1 text-left w-28">Mode</th>
             {CODECS.map((codec) => (
               <th key={codec} className="border border-light p-1 text-center w-16">
                 {codec}

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -269,12 +269,13 @@ export function ScalabilityMode() {
           onClick={runCheck}
           disabled={checkState.value === "running"}
           className={`
-            px-3 py-1 text-sm rounded border
+            px-2 py-1 text-sm rounded border
+            font-normal leading-normal text-center
             transition-colors duration-150
             ${
               checkState.value === "running"
-                ? "text-gray-400 bg-gray-600 border-gray-600 cursor-not-allowed"
-                : "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:border-blue-700 cursor-pointer"
+                ? "text-gray-400 bg-gray-500 border-gray-500 cursor-not-allowed"
+                : "text-black bg-bs-light border-bs-light hover:bg-[#e2e6ea] hover:border-[#dae0e5] cursor-pointer"
             }
           `}
         >

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -181,17 +181,17 @@ async function checkScalabilityModeSupport(
 function getStatusBgClass(status: CheckStatus): string {
   switch (status) {
     case "unchecked":
-      return "bg-a11y-gray";
+      return "bg-gray-600";
     case "checking":
-      return "bg-a11y-yellow";
+      return "bg-a11y-yellow text-black";
     case "supported":
-      return "bg-a11y-blue";
+      return "bg-a11y-sky-blue";
     case "unsupported":
       return "bg-a11y-orange";
     case "error":
       return "bg-a11y-vermilion";
     default:
-      return "bg-a11y-gray";
+      return "bg-gray-600";
   }
 }
 

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -176,21 +176,39 @@ async function checkScalabilityModeSupport(
   }
 }
 
-// ステータス表示コンポーネント
-function StatusCell({ status }: { status: CheckStatus }) {
+// ステータスに応じた背景色クラスを返す
+function getStatusBgClass(status: CheckStatus): string {
   switch (status) {
     case "unchecked":
-      return <span className="text-gray-500">-</span>;
+      return "bg-gray-700";
     case "checking":
-      return <span className="text-yellow-500">...</span>;
+      return "bg-yellow-600";
     case "supported":
-      return <span className="text-green-500">OK</span>;
+      return "bg-green-600";
     case "unsupported":
-      return <span className="text-red-500">NG</span>;
+      return "bg-red-600";
     case "error":
-      return <span className="text-orange-500">ERR</span>;
+      return "bg-orange-600";
     default:
-      return <span className="text-gray-500">-</span>;
+      return "bg-gray-700";
+  }
+}
+
+// ステータスに応じたラベルを返す
+function getStatusLabel(status: CheckStatus): string {
+  switch (status) {
+    case "unchecked":
+      return "-";
+    case "checking":
+      return "...";
+    case "supported":
+      return "OK";
+    case "unsupported":
+      return "NG";
+    case "error":
+      return "ERR";
+    default:
+      return "-";
   }
 }
 
@@ -277,11 +295,17 @@ export function ScalabilityMode() {
           {SCALABILITY_MODES.map((mode) => (
             <tr key={mode}>
               <td className="border border-light p-1 font-mono">{mode}</td>
-              {CODECS.map((codec) => (
-                <td key={`${codec}-${mode}`} className="border border-light p-1 text-center">
-                  <StatusCell status={results.value[codec][mode]} />
-                </td>
-              ))}
+              {CODECS.map((codec) => {
+                const status = results.value[codec][mode];
+                return (
+                  <td
+                    key={`${codec}-${mode}`}
+                    className={`border border-light p-1 text-center text-white ${getStatusBgClass(status)}`}
+                  >
+                    {getStatusLabel(status)}
+                  </td>
+                );
+              })}
             </tr>
           ))}
         </tbody>

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -177,21 +177,21 @@ async function checkScalabilityModeSupport(
 }
 
 // ステータスに応じた背景色クラスを返す
-// 色覚異常に配慮し、赤緑ではなく青とオレンジの組み合わせを使用
+// 色覚異常に配慮した Okabe-Ito パレットを使用
 function getStatusBgClass(status: CheckStatus): string {
   switch (status) {
     case "unchecked":
-      return "bg-gray-600";
+      return "bg-a11y-gray";
     case "checking":
-      return "bg-yellow-500";
+      return "bg-a11y-yellow";
     case "supported":
-      return "bg-sky-500";
+      return "bg-a11y-blue";
     case "unsupported":
-      return "bg-orange-500";
+      return "bg-a11y-orange";
     case "error":
-      return "bg-purple-500";
+      return "bg-a11y-vermilion";
     default:
-      return "bg-gray-600";
+      return "bg-a11y-gray";
   }
 }
 

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -152,6 +152,19 @@ async function checkScalabilityModeSupport(
     parameters.encodings[0].scalabilityMode = mode;
 
     await sender.setParameters(parameters);
+
+    // setParameters 後に getParameters で実際に反映されているか確認
+    // Safari など一部ブラウザは setParameters が成功しても scalabilityMode を無視する
+    const updatedParameters = sender.getParameters();
+    // @ts-ignore: scalabilityMode は標準には存在しないが、ブラウザによってはサポートしている
+    const actualMode = updatedParameters.encodings[0]?.scalabilityMode;
+    if (actualMode !== mode) {
+      return {
+        supported: false,
+        error: `scalabilityMode not applied: expected ${mode}, got ${actualMode}`,
+      };
+    }
+
     return { supported: true };
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : String(e);

--- a/src/components/DebugPane/ScalabilityMode.tsx
+++ b/src/components/DebugPane/ScalabilityMode.tsx
@@ -177,20 +177,21 @@ async function checkScalabilityModeSupport(
 }
 
 // ステータスに応じた背景色クラスを返す
+// 色覚異常に配慮し、赤緑ではなく青とオレンジの組み合わせを使用
 function getStatusBgClass(status: CheckStatus): string {
   switch (status) {
     case "unchecked":
-      return "bg-gray-700";
+      return "bg-gray-600";
     case "checking":
-      return "bg-yellow-600";
+      return "bg-yellow-500";
     case "supported":
-      return "bg-green-600";
+      return "bg-sky-500";
     case "unsupported":
-      return "bg-red-600";
+      return "bg-orange-500";
     case "error":
-      return "bg-orange-600";
+      return "bg-purple-500";
     default:
-      return "bg-gray-700";
+      return "bg-gray-600";
   }
 }
 

--- a/src/components/DebugPane/index.tsx
+++ b/src/components/DebugPane/index.tsx
@@ -19,6 +19,8 @@ import { SignalingMessages } from "./SignalingMessages.tsx";
 import { Stats } from "./Stats.tsx";
 import { TimelineMessages } from "./TimelineMessages.tsx";
 
+const enableSvcTab = import.meta.env.VITE_DEBUG_PANEL_SVC === "true";
+
 export function DebugPane() {
   const debugValue = debug.value;
   const debugTypeValue = debugType.value;
@@ -37,7 +39,7 @@ export function DebugPane() {
       // key === 'api' ||
       key === "rpc" ||
       key === "codec" ||
-      key === "svc"
+      (enableSvcTab && key === "svc")
     ) {
       setDebugType(key);
       // URL の query string を更新
@@ -92,9 +94,11 @@ export function DebugPane() {
         <Tab eventKey="codec" title="Codec">
           <CapabilitiesCodec />
         </Tab>
-        <Tab eventKey="svc" title="SVC">
-          <ScalabilityMode />
-        </Tab>
+        {enableSvcTab && (
+          <Tab eventKey="svc" title="SVC">
+            <ScalabilityMode />
+          </Tab>
+        )}
       </Tabs>
     </div>
   );

--- a/src/components/DebugPane/index.tsx
+++ b/src/components/DebugPane/index.tsx
@@ -13,6 +13,7 @@ import { NotifyMaxMessages } from "./NotifyMaxMessages.tsx";
 import { NotifyMessages } from "./NotifyMessages.tsx";
 import { PushMessages } from "./PushMessages.tsx";
 import { Rpc } from "./Rpc.tsx";
+import { ScalabilityMode } from "./ScalabilityMode.tsx";
 import { SendDataChannelMessagingMessage } from "./SendDataChannelMessagingMessage.tsx";
 import { SignalingMessages } from "./SignalingMessages.tsx";
 import { Stats } from "./Stats.tsx";
@@ -35,7 +36,8 @@ export function DebugPane() {
       key === "messaging" ||
       // key === 'api' ||
       key === "rpc" ||
-      key === "codec"
+      key === "codec" ||
+      key === "svc"
     ) {
       setDebugType(key);
       // URL の query string を更新
@@ -89,6 +91,9 @@ export function DebugPane() {
         </Tab>
         <Tab eventKey="codec" title="Codec">
           <CapabilitiesCodec />
+        </Tab>
+        <Tab eventKey="svc" title="SVC">
+          <ScalabilityMode />
         </Tab>
       </Tabs>
     </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,7 @@ export const DEBUG_TYPES = [
   "api",
   "rpc",
   "codec",
+  "svc",
 ] as const;
 
 export const AUDIO_CONTENT_HINTS = ["", "speech", "speech-recognition", "music"] as const;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_SORA_SIGNALING_URL: string;
   readonly VITE_VIRTUAL_BACKGROUND_ASSETS_PATH: string;
   readonly VITE_NOISE_SUPPRESSION_ASSETS_PATH: string;
+  readonly VITE_DEBUG_PANEL_SVC: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
- 各コーデック (VP8, VP9, AV1, H.264, H.265) と scalabilityMode の 組み合わせがブラウザでサポートされているかをチェックする機能を追加
- ローカル 1:1 接続を確立して正確なサポート状況を判定
- 37 種類の scalabilityMode (L系, Lh系, S系, KEY系) に対応