### PR TITLE
0076 LocalVideo に映像トラックの無効化ワークアラウンドを適用しないようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@
   - @voluntas
 - [FIX] DuckDB 初期化完了前の接続でセッションが永続化されない競合を修正する
   - @voluntas
+- [FIX] LocalVideo に映像トラックの無効化ワークアラウンドを適用しないようにする
+  - Windows Chrome で NVIDIA を利用した H.265 の映像送信が止まるケースがある問題についての対応
+  - @miosakuma
 
 ### misc
 

--- a/issues/0076-bug-fix-skip-local-video-track-workaround.md
+++ b/issues/0076-bug-fix-skip-local-video-track-workaround.md
@@ -51,6 +51,14 @@ LocalVideo の表示処理が送信に使用している映像トラックを一
 
 既存の `tests/sendrecv.test.ts`、`tests/sendonly.test.ts`、`tests/recvonly.test.ts` は接続後に待機して切断するテストであり、現在は VP9 接続を使用している。H.265 HWA のフレームカウンターと `track.enabled` の確認はこれらの既存テストでは直接検証しないため、上記のブラウザー確認を必須とする。E2E の環境変数は `tests/helpers/env.ts` の定義に従い、`E2E_TEST_SORA_SIGNALING_URL` のみ必須で、他 2 つは未設定時に空文字となる。
 
+### 検証結果
+
+- 実施日: 2026-08-26
+- 環境: Windows Chrome 152.0.7977.54、H.265 NVIDIA HEVC Encoder MFT
+- 接続条件: `role=sendrecv`、`videoCodecType=H265`
+- `framesEncoded` と `framesSent` が継続して増加することを確認した
+- 他の接続中の devtools で映像が受信できることを 10 回確認した
+
 ## 関連 issue
 
 - 0043: `audioOutput` 変更時の stream 設定 effect 再実行と `setSinkId` エラー処理を扱う。LocalVideo の H.265 HWA 送信停止とは目的が異なるが、同じ `VideoElement` の effect を変更するため、実装時は本 issue の `props.localVideo` ガードと依存配列を維持する

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -49,14 +49,7 @@ function VideoElement(props: VideoProps) {
       return;
     }
 
-    // Chrome で first video frame まで音声が出力されない現象のワークアラウンド
-    // 一旦 video tracks を disabled にしておき、 loadedmetadata イベントで有効にする
-    // 参照: https://bugs.chromium.org/p/chromium/issues/detail?id=403710
     let originalEnabled: boolean | undefined;
-    for (const track of stream.getVideoTracks()) {
-      originalEnabled = track.enabled;
-      track.enabled = false;
-    }
     const onLoadedMetadata = (): void => {
       for (const track of stream.getVideoTracks()) {
         if (originalEnabled !== undefined) {
@@ -64,7 +57,16 @@ function VideoElement(props: VideoProps) {
         }
       }
     };
-    videoElement.addEventListener("loadedmetadata", onLoadedMetadata);
+    if (!props.localVideo) {
+      // Chrome で first video frame まで音声が出力されない現象のワークアラウンド
+      // 一旦 video tracks を disabled にしておき、 loadedmetadata イベントで有効にする
+      // 参照: https://bugs.chromium.org/p/chromium/issues/detail?id=403710
+      for (const track of stream.getVideoTracks()) {
+        originalEnabled = track.enabled;
+        track.enabled = false;
+      }
+      videoElement.addEventListener("loadedmetadata", onLoadedMetadata);
+    }
 
     videoElement.srcObject = stream;
     // 音声出力先の指定は srcObject 設定後のこの useEffect に集約する
@@ -74,15 +76,17 @@ function VideoElement(props: VideoProps) {
 
     // stream 変更時にリスナーが蓄積するのを防ぐため cleanup で removeEventListener する
     return () => {
-      videoElement.removeEventListener("loadedmetadata", onLoadedMetadata);
-      // onloadedmetadata が呼ばれない場合にアンマウントされた場合は track.enabled をオリジナルの状態に戻す
-      for (const track of stream.getVideoTracks()) {
-        if (originalEnabled !== undefined) {
-          track.enabled = originalEnabled;
+      if (!props.localVideo) {
+        videoElement.removeEventListener("loadedmetadata", onLoadedMetadata);
+        // onloadedmetadata が呼ばれない場合にアンマウントされた場合は track.enabled をオリジナルの状態に戻す
+        for (const track of stream.getVideoTracks()) {
+          if (originalEnabled !== undefined) {
+            track.enabled = originalEnabled;
+          }
         }
       }
     };
-  }, [stream, audioOutput]);
+  }, [stream, audioOutput, props.localVideo]);
 
   return (
     <video


### PR DESCRIPTION
## 概要

LocalVideo の表示処理で映像トラックの `enabled` を変更しないようにする。

## 変更内容

- `localVideo=true` の場合は、映像トラックの無効化ワークアラウンドを適用しない
- RemoteVideo では既存のワークアラウンドを維持する
- `stream` 設定用 `useEffect` の依存配列に `localVideo` を追加する
- 変更履歴を更新する

## 検証結果

- Windows Chrome 152.0.7977.54
- NVIDIA H.265 HEVC Encoder MFT
- `role=sendrecv`、`videoCodecType=H265`
- `framesEncoded` と `framesSent` が継続して増加することを確認
- 他の DevTools から映像を 10 回受信できることを確認

## テスト

- [x] `vp check`
- [x] `vp build`
- [x] `vp test run`
- [x] `vp test run --config vitest.ct.config.ts`
- [x] `vp exec playwright test --project=chromium`（23 テスト成功）